### PR TITLE
Fix typo

### DIFF
--- a/TeknoParrotUi/Views/GameRunning.xaml.cs
+++ b/TeknoParrotUi/Views/GameRunning.xaml.cs
@@ -547,12 +547,12 @@ namespace TeknoParrotUi.Views
                     // TODO: LOL CLEAN UP PLS
                     var isOriginalVersion = true;
 
-                    if(!File.Exists(Path.Combine(Path.GetDirectoryName(_gameLocation), "AMCUS", "AMAuthd.exe")))
+                    if(File.Exists(Path.Combine(Path.GetDirectoryName(_gameLocation), "AMCUS", "AMAuthd.exe")))
                     {
                         isOriginalVersion = false;
                     }
 
-                    if (!File.Exists(Path.Combine(Path.GetDirectoryName(_gameLocation), "AMCUS", "iauthdll.dll")))
+                    if (File.Exists(Path.Combine(Path.GetDirectoryName(_gameLocation), "AMCUS", "iauthdll.dll")))
                     {
                         isOriginalVersion = false;
                     }


### PR DESCRIPTION
Fixes MKDX banapass (because of typo, isOriginalVersion was always true, which means it would never run AMAuthd which is needed for banapass)