### PR TITLE
Small changes to discord rich presence

### DIFF
--- a/TeknoParrotUi/MainWindow.xaml.cs
+++ b/TeknoParrotUi/MainWindow.xaml.cs
@@ -73,15 +73,14 @@ namespace TeknoParrotUi
                 }
             }).Start();
 
-            if (_parrotData.UseDiscordRPC && File.Exists("discord-rpc.dll"))
-            {
+            if (_parrotData.UseDiscordRPC)
                 DiscordRPC.UpdatePresence(new DiscordRPC.RichPresence
                 {
-                    details = "Main Menu"
+                    details = "Main Menu",
+                    largeImageKey = "teknoparrot",
                 });
-            }
 
-            Title = "Teknoparrot UI " + GameVersion.CurrentVersion;
+            Title = "TeknoParrot UI " + GameVersion.CurrentVersion;
         }
 
         private void CreateConfigValue()

--- a/TeknoParrotUi/Views/GameRunning.xaml.cs
+++ b/TeknoParrotUi/Views/GameRunning.xaml.cs
@@ -323,6 +323,7 @@ namespace TeknoParrotUi.Views
             if (_parrotData.UseDiscordRPC) DiscordRPC.UpdatePresence(new DiscordRPC.RichPresence
             {
                 details = _gameProfile.GameName,
+                largeImageKey = _gameProfile.GameName.Replace(" ", ""),
                 //https://stackoverflow.com/a/17632585
                 startTimestamp = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds
             });

--- a/TeknoParrotUi/Views/GameRunning.xaml.cs
+++ b/TeknoParrotUi/Views/GameRunning.xaml.cs
@@ -323,7 +323,7 @@ namespace TeknoParrotUi.Views
             if (_parrotData.UseDiscordRPC) DiscordRPC.UpdatePresence(new DiscordRPC.RichPresence
             {
                 details = _gameProfile.GameName,
-                largeImageKey = _gameProfile.GameName.Replace(" ", ""),
+                largeImageKey = _gameProfile.GameName.Replace(" ", "").ToLower(),
                 //https://stackoverflow.com/a/17632585
                 startTimestamp = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds
             });


### PR DESCRIPTION
Shows game icons if they're added to the app (at https://discordapp.com/developers/applications/508838453937438752/rich-presence/assets )

A asset named "teknoparrot" will show up when the user is on the main menu, and name a asset with the same name as a game (minus spaces) will show up when the user is playing the game

So, if you wanted to make a icon for "King of Fighters Maximum Impact Regulation A" , upload a asset with the name "kingoffightersmaximumimpactregulationa"

I don't have any icons that fit properly in the box yet, I asked POOTERMAN and I'm still waiting for a response