### PR TITLE
[WMMT5] Add event mode options to Terminal Emulator

### DIFF
--- a/TeknoParrotUi.Common/GameProfiles/WMMT5.xml
+++ b/TeknoParrotUi.Common/GameProfiles/WMMT5.xml
@@ -8,7 +8,7 @@
   <TestMenuExtraParameters/>
   <IconName>Icons\WMMT5.png</IconName>
   <EmulationProfile>NamcoWmmt5</EmulationProfile>
-  <GameProfileRevision>10</GameProfileRevision>
+  <GameProfileRevision>11</GameProfileRevision>
   <Is64Bit>true</Is64Bit>
   <HasSeparateTestMode>false</HasSeparateTestMode>
   <EmulatorType>OpenParrot</EmulatorType>
@@ -18,6 +18,12 @@
       <CategoryName>General</CategoryName>
       <FieldName>FreePlay</FieldName>
       <FieldValue>1</FieldValue>
+      <FieldType>Bool</FieldType>
+    </FieldInformation>
+    <FieldInformation>
+      <CategoryName>General</CategoryName>
+      <FieldName>Event2P</FieldName>
+      <FieldValue>0</FieldValue>
       <FieldType>Bool</FieldType>
     </FieldInformation>
     <FieldInformation>

--- a/TeknoParrotUi.Common/GameProfiles/WMMT5.xml
+++ b/TeknoParrotUi.Common/GameProfiles/WMMT5.xml
@@ -22,14 +22,20 @@
     </FieldInformation>
     <FieldInformation>
       <CategoryName>General</CategoryName>
-      <FieldName>Event2P</FieldName>
+      <FieldName>TerminalEmulator</FieldName>
+      <FieldValue>1</FieldValue>
+      <FieldType>Bool</FieldType>
+    </FieldInformation>
+    <FieldInformation>
+      <CategoryName>TerminalEmuConfig</CategoryName>
+      <FieldName>2P Event Mode</FieldName>
       <FieldValue>0</FieldValue>
       <FieldType>Bool</FieldType>
     </FieldInformation>
     <FieldInformation>
-      <CategoryName>General</CategoryName>
-      <FieldName>TerminalEmulator</FieldName>
-      <FieldValue>1</FieldValue>
+      <CategoryName>TerminalEmuConfig</CategoryName>
+      <FieldName>4P Event Mode</FieldName>
+      <FieldValue>0</FieldValue>
       <FieldType>Bool</FieldType>
     </FieldInformation>
     <FieldInformation>


### PR DESCRIPTION
This goes with the pull request for OpenParrot that adds the ability to toggle on Event Mode, for either 2P or 4P.