### PR TITLE
Discord RPC fixes (again..)

### DIFF
--- a/TeknoParrotUi.Common/JoystickHelper.cs
+++ b/TeknoParrotUi.Common/JoystickHelper.cs
@@ -8,11 +8,9 @@ namespace TeknoParrotUi.Common
 {
     public class JoystickHelper
     {
-        public static bool firstTime = false;
         /// <summary>
         /// Serializes Lazydata.ParrotData to a ParrotData.xml file.
         /// </summary>
-        /// <param name="joystick"></param>
         public static void Serialize()
         {
             var serializer = new XmlSerializer(typeof(ParrotData));
@@ -30,7 +28,6 @@ namespace TeknoParrotUi.Common
         {
             if (!File.Exists("ParrotData.xml"))
             {
-                firstTime = true;
                 MessageBox.Show("Seems like this is first time you are running me, please set emulation settings.", "Hello World");
                 Lazydata.ParrotData = new ParrotData();
                 Serialize();

--- a/TeknoParrotUi/App.xaml.cs
+++ b/TeknoParrotUi/App.xaml.cs
@@ -127,8 +127,6 @@ namespace TeknoParrotUi
             ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            DiscordRPC.StartOrShutdown();
-
             if (e.Args.Length != 0)
             {
                 // Process command args
@@ -145,6 +143,9 @@ namespace TeknoParrotUi
                     return;
                 }
             }
+
+            DiscordRPC.StartOrShutdown();
+
             StartApp();
         }
 

--- a/TeknoParrotUi/Helpers/DiscordRpc.cs
+++ b/TeknoParrotUi/Helpers/DiscordRpc.cs
@@ -76,7 +76,7 @@ public class DiscordRPC
                         if (entry.FullName == "discord-rpc/win32-dynamic/bin/discord-rpc.dll")
                         {
                             using (var entryStream = entry.Open())
-                            using (var dll = File.Create("discord-rpc.dll"))
+                            using (var dll = File.Create(RPC_PATH))
                             {
                                 entryStream.CopyTo(dll);
                             }

--- a/TeknoParrotUi/MainWindow.xaml.cs
+++ b/TeknoParrotUi/MainWindow.xaml.cs
@@ -361,7 +361,7 @@ namespace TeknoParrotUi
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
             //CHECK IF I LEFT DEBUG SET WRONG!!
-#if DEBUG
+#if !DEBUG
             if (Lazydata.ParrotData.CheckForUpdates)
             {
                 CheckGitHub("TeknoParrotUI");

--- a/TeknoParrotUi/Views/Library.xaml.cs
+++ b/TeknoParrotUi/Views/Library.xaml.cs
@@ -141,8 +141,8 @@ namespace TeknoParrotUi.Views
         {
             if (emuOnly)
             {
-                loaderDll = "dont care";
-                loaderExe = "dont care";
+                loaderDll = string.Empty;
+                loaderExe = string.Empty;
                 return true;
             }
 


### PR DESCRIPTION
discord-rpc.dll moved to the libs folder, it's automatically downloaded if it doesn't exist and it's disabled if the download fails (no messagebox shown), also doesn't load if command line arguments are used