### PR TITLE
More updater changes

### DIFF
--- a/TeknoParrotUi/MainWindow.xaml.cs
+++ b/TeknoParrotUi/MainWindow.xaml.cs
@@ -339,7 +339,7 @@ namespace TeknoParrotUi
                     {
                         onlineVersion = onlineVersion.Split('_')[1];
                     }
-                    Debug.WriteLine($"{component}: local: {localVersion} | github: {onlineVersion}");
+                    Debug.WriteLine($"{component.name}: local: {localVersion} | github: {onlineVersion}");
                     if (localVersion != onlineVersion)
                     {
                         new GitHubUpdates(component, githubRelease).Show();

--- a/TeknoParrotUi/MainWindow.xaml.cs
+++ b/TeknoParrotUi/MainWindow.xaml.cs
@@ -342,7 +342,7 @@ namespace TeknoParrotUi
                     Debug.WriteLine($"{component.name}: local: {localVersion} | github: {onlineVersion}");
                     if (localVersion != onlineVersion)
                     {
-                        new GitHubUpdates(component, githubRelease).Show();
+                        new GitHubUpdates(component, githubRelease, localVersion, onlineVersion).Show();
                     }
                 }
                 else

--- a/TeknoParrotUi/Views/DownloadWindow.xaml.cs
+++ b/TeknoParrotUi/Views/DownloadWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.IO;
 using System.IO.Compression;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace TeknoParrotUi.Views
 {
@@ -120,9 +121,11 @@ namespace TeknoParrotUi.Views
             {
                 using (_wc)
                 {
+                    var inMemory = string.IsNullOrEmpty(_output);
+                    Debug.WriteLine($"Downloading {_link} {(!inMemory ? $"to {_output}" : "")}");
                     _wc.DownloadProgressChanged += wc_DownloadProgressChanged;
                     // download byte array instead of dropping a file
-                    if (string.IsNullOrEmpty(_output))
+                    if (inMemory)
                     {
                         _wc.DownloadDataCompleted += wc_DownloadDataCompleted;
                         _wc.DownloadDataAsync(new Uri(_link));

--- a/TeknoParrotUi/Views/GitHubUpdates.xaml
+++ b/TeknoParrotUi/Views/GitHubUpdates.xaml
@@ -11,7 +11,8 @@
         Title="TeknoParrot" Height="236.313" Width="649.162">
     <Grid>
         <Label Content="There is a new update available." Margin="52,0,49,151" FontSize="36"/>
-        <Label x:Name="labelUpdated" Content="TeknoParrot UI" HorizontalAlignment="Left" Margin="100,68,0,0" VerticalAlignment="Top" Height="39" Width="225" FontSize="20"/>
+        <Label x:Name="labelUpdated" Content="Component" HorizontalAlignment="Left" Margin="50,56,0,0" VerticalAlignment="Top" Height="39" Width="225" FontSize="20"/>
+        <Label x:Name="labelVersion" Content="X.X.X.X to Z.Z.Z.Z" HorizontalAlignment="Left" Margin="50,85,0,0" VerticalAlignment="Top" Height="39" Width="225" FontSize="20"/>
         <Button x:Name="buttonUpdate" Content="Update" HorizontalAlignment="Left" Margin="354,127,0,0" VerticalAlignment="Top" Width="126" Height="50"  FontSize="20" Click="ButtonUpdate_Click"/>
         <Button x:Name="buttonCancel" Content="Cancel" HorizontalAlignment="Left" Margin="100,127,0,0" VerticalAlignment="Top" Width="126" Background="#FFF40303" Foreground="#DDFFFFFF" BorderBrush="#FFF40303" Height="50" FontSize="20" Click="ButtonCancel_Click"/>
         <Button Content="Check Changelog" HorizontalAlignment="Left" Margin="354,68,0,0" VerticalAlignment="Top" Width="146" Click="BtnChangelog"/>

--- a/TeknoParrotUi/Views/GitHubUpdates.xaml.cs
+++ b/TeknoParrotUi/Views/GitHubUpdates.xaml.cs
@@ -53,6 +53,9 @@ namespace TeknoParrotUi.Views
 
         private void afterDownload(object sender, EventArgs e)
         {
+            if (downloadWindow.data == null)
+                return;
+
             bool isUI = _componentUpdated.name == "TeknoParrotUI";
             string destinationFolder = !string.IsNullOrEmpty(_componentUpdated.folderOverride) ? _componentUpdated.folderOverride : _componentUpdated.name;
 

--- a/TeknoParrotUi/Views/GitHubUpdates.xaml.cs
+++ b/TeknoParrotUi/Views/GitHubUpdates.xaml.cs
@@ -65,15 +65,25 @@ namespace TeknoParrotUi.Views
             {
                 foreach (var entry in zip.Entries)
                 {
-                    var dest = isUI ? entry.FullName : Path.Combine(destinationFolder, entry.FullName);
-                    Debug.WriteLine($"Updater file: {entry.FullName} extracting to: {dest}");
+                    var name = entry.FullName;
+
+                    // directory
+                    if (name.EndsWith("/"))
+                    {
+                        Directory.CreateDirectory(name);
+                        Debug.WriteLine($"Updater directory entry: {name}");
+                        continue;
+                    }
+
+                    var dest = isUI ? name : Path.Combine(destinationFolder, name);
+                    Debug.WriteLine($"Updater file: {name} extracting to: {dest}");
 
                     try
                     {
                         if (File.Exists(dest))
                             File.Delete(dest);
                     }
-                    catch (UnauthorizedAccessException uae)
+                    catch (UnauthorizedAccessException)
                     {
                         // couldn't delete, just move for now
                         File.Move(dest, dest + ".bak");

--- a/TeknoParrotUi/Views/GitHubUpdates.xaml.cs
+++ b/TeknoParrotUi/Views/GitHubUpdates.xaml.cs
@@ -30,11 +30,12 @@ namespace TeknoParrotUi.Views
         private readonly UpdaterComponent _componentUpdated;
         private readonly GithubRelease _latestRelease;
         private DownloadWindow downloadWindow;
-        public GitHubUpdates(UpdaterComponent componentUpdated, GithubRelease latestRelease)
+        public GitHubUpdates(UpdaterComponent componentUpdated, GithubRelease latestRelease, string local, string online)
         {
             InitializeComponent();
             _componentUpdated = componentUpdated;
             labelUpdated.Content = componentUpdated.name;
+            labelVersion.Content = $"{(!string.IsNullOrEmpty(local) ? $"{local} to " : "")}{online}";
             _latestRelease = latestRelease;
         }
 

--- a/TeknoParrotUi/Views/GitHubUpdates.xaml.cs
+++ b/TeknoParrotUi/Views/GitHubUpdates.xaml.cs
@@ -120,6 +120,8 @@ namespace TeknoParrotUi.Views
                     Application.Current.Shutdown();
                 }
             }
+
+            this.Close();
         }
 
         private void ButtonUpdate_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
* Show current version number and newest version number on the updater window
* Properly extract new directories 
* Properly handle window cancel / exiting
* Close updater window when download's finished
* Make "download all icons" button download every icon at once in a zip file instead of downloading one at a time (NOTE: progress bar doesn't work for this because of how github works with zip files)
* Fix debugging messages