### PR TITLE
removed 5 second timer from when game ends to going back to library

### DIFF
--- a/TeknoParrotUi/Views/GameRunning.xaml.cs
+++ b/TeknoParrotUi/Views/GameRunning.xaml.cs
@@ -722,7 +722,6 @@ namespace TeknoParrotUi.Views
                         progressBar.IsIndeterminate = false;
                         Application.Current.Windows.OfType<MainWindow>().Single().menuButton.IsEnabled = true;
                     });
-                    Thread.Sleep(5000);
                     Application.Current.Dispatcher.Invoke(delegate
                         {
                             Application.Current.Windows.OfType<MainWindow>().Single().contentControl.Content = _library;


### PR DESCRIPTION
seems to cause issues if you manually go back, like if you then start another game before the 5 seconds are up, it'll close gamerunning meaning you'll probably get a JVS error (found this on ID8)