### PR TITLE
Add option to disable Dual JVS emulation

### DIFF
--- a/TeknoParrotUi.Common/GameProfiles/VT4.xml
+++ b/TeknoParrotUi.Common/GameProfiles/VT4.xml
@@ -8,7 +8,7 @@
   <TestMenuExtraParameters/>
   <IconName>Icons\VT4.png</IconName>
   <EmulationProfile>VirtuaTennis4</EmulationProfile>
-  <GameProfileRevision>4</GameProfileRevision>
+  <GameProfileRevision>5</GameProfileRevision>
   <HasSeparateTestMode>true</HasSeparateTestMode>
   <EmulatorType>TeknoParrot</EmulatorType>
   <ConfigValues>
@@ -39,6 +39,12 @@
     <FieldInformation>
       <CategoryName>General</CategoryName>
       <FieldName>Windowed</FieldName>
+      <FieldValue>1</FieldValue>
+      <FieldType>Bool</FieldType>
+    </FieldInformation>
+    <FieldInformation>
+      <CategoryName>General</CategoryName>
+      <FieldName>DualJvsEmulation</FieldName>
       <FieldValue>1</FieldValue>
       <FieldType>Bool</FieldType>
     </FieldInformation>

--- a/TeknoParrotUi/Views/GameRunning.xaml.cs
+++ b/TeknoParrotUi/Views/GameRunning.xaml.cs
@@ -528,6 +528,8 @@ namespace TeknoParrotUi.Views
                 InputCode.ButtonMode != EmulationProfile.EuropaRSegaRally3 &&
                 InputCode.ButtonMode != EmulationProfile.FastIo)
             {
+                bool DualJvsEmulation = _gameProfile.ConfigValues.Any(x => x.FieldName == "DualJvsEmulation" && x.FieldValue == "1");
+
                 // TODO: MAYBE MAKE THESE XML BASED?
                 switch (InputCode.ButtonMode)
                 {
@@ -584,6 +586,15 @@ namespace TeknoParrotUi.Views
                         JvsPackageEmulator.JvsSwitchCount = 0x18;
                         break;
                     case EmulationProfile.VirtuaTennis4:
+                        if (DualJvsEmulation)
+                        {
+                            JvsPackageEmulator.DualJvsEmulation = true;
+                        }
+                        else
+                        {
+                            JvsPackageEmulator.DualJvsEmulation = false;
+                        }
+                        break;
                     case EmulationProfile.ArcadeLove:
                         JvsPackageEmulator.DualJvsEmulation = true;
                         break;


### PR DESCRIPTION
until someone fixes it, this is a workaround for VT4 FPS issue, but obviously only 2 player will work if its disabled

also if disabled, you need to set buttons like this in the UI:
Player 3 = Player 1
Player 4 = Player 2