### PR TITLE
added temporary fix for hints.dat causing game to not load

### DIFF
--- a/TeknoParrotUi.Common/GameProfile.cs
+++ b/TeknoParrotUi.Common/GameProfile.cs
@@ -16,6 +16,7 @@ namespace TeknoParrotUi.Common
         public string TestMenuExtraParameters { get; set; }
         public string IconName { get; set; }
         public string ValidMd5 { get; set; }
+        public bool ResetHint { get; set; }
         public string Description { get; set; }
         [XmlIgnore]
         public Description GameInfo { get; set; }

--- a/TeknoParrotUi.Common/GameProfiles/WMMT5.xml
+++ b/TeknoParrotUi.Common/GameProfiles/WMMT5.xml
@@ -8,11 +8,12 @@
   <TestMenuExtraParameters/>
   <IconName>Icons\WMMT5.png</IconName>
   <EmulationProfile>NamcoWmmt5</EmulationProfile>
-  <GameProfileRevision>14</GameProfileRevision>
+  <GameProfileRevision>15</GameProfileRevision>
   <Is64Bit>true</Is64Bit>
   <HasSeparateTestMode>false</HasSeparateTestMode>
   <EmulatorType>OpenParrot</EmulatorType>
   <ValidMd5>MD5\WMMT5.md5</ValidMd5>
+  <ResetHint>true</ResetHint>
   <ConfigValues>
     <FieldInformation>
       <CategoryName>General</CategoryName>

--- a/TeknoParrotUi/Views/GameRunning.xaml.cs
+++ b/TeknoParrotUi/Views/GameRunning.xaml.cs
@@ -720,6 +720,14 @@ namespace TeknoParrotUi.Views
                     gameArguments = $"\"{_gameLocation}\" {extra}";
                 }
 
+                if (_gameProfile.ResetHint)
+                {
+                    if(File.Exists(Path.GetDirectoryName(_gameProfile.GamePath) + "\\hints.dat"))
+                    {
+                        File.Delete(Path.GetDirectoryName(_gameProfile.GamePath) + "\\hints.dat");
+                    }
+                }
+
                 var info = new ProcessStartInfo(loaderExe, $"{loaderDll} {gameArguments}");
 
                 if (_gameProfile.msysType > 0)


### PR DESCRIPTION
this is still an issue on wmmt5, this is a temporary thing that adds a bool to the gameprofile that when set to true, deletes hints.dat from the game folder if it's there. that way we can just set it to false when its all working right :D