### PR TITLE
Add DPad support for Theatrhythm, as well as tidied up button checking

### DIFF
--- a/TeknoParrotUi.Common/InputCode.cs
+++ b/TeknoParrotUi.Common/InputCode.cs
@@ -179,6 +179,22 @@ namespace TeknoParrotUi.Common
         {
             return Down.HasValue && Down.Value;
         }
+        public bool FFLeftPressed()
+        {
+            return Button3.HasValue && Button3.Value;
+        }
+        public bool FFRightPressed()
+        {
+            return Button4.HasValue && Button4.Value;
+        }
+        public bool FFUpPressed()
+        {
+            return Button1.HasValue && Button1.Value;
+        }
+        public bool FFDownPressed()
+        {
+            return Button2.HasValue && Button2.Value;
+        }
         private bool? _up;
         private bool? _down;
         private bool? _right;

--- a/TeknoParrotUi.Common/InputProfiles/Helpers/DigitalHelper.cs
+++ b/TeknoParrotUi.Common/InputProfiles/Helpers/DigitalHelper.cs
@@ -331,6 +331,14 @@ namespace TeknoParrotUi.Common.InputProfiles.Helpers
                         InputCode.SetPlayerDirection(playerButtons, Direction.VerticalCenter);
                     if (direction == Direction.Down && !playerButtons.UpPressed())
                         InputCode.SetPlayerDirection(playerButtons, Direction.VerticalCenter);
+                    if (direction == Direction.FFLeft && !playerButtons.RightPressed())
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFHoriCenter);
+                    if (direction == Direction.FFRight && !playerButtons.LeftPressed())
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFHoriCenter);
+                    if (direction == Direction.FFUp && !playerButtons.DownPressed())
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFVertCenter);
+                    if (direction == Direction.FFDown && !playerButtons.UpPressed())
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFVertCenter);
                 }
             }
 
@@ -450,7 +458,7 @@ namespace TeknoParrotUi.Common.InputProfiles.Helpers
             if ((JoystickOffset)button.Button != state.Offset)
                 return;
             // POV
-            if (button.Button >= 32 && button.Button <= 44)
+            if (button.Button >= 32 && button.Button <= 44 && !(direction == Direction.FFUp || direction == Direction.FFDown || direction == Direction.FFRight || direction == Direction.FFLeft || direction == Direction.FFHoriCenter || direction == Direction.FFVertCenter))
             {
                 switch (state.Value)
                 {
@@ -485,6 +493,49 @@ namespace TeknoParrotUi.Common.InputProfiles.Helpers
                     case 31500:
                         InputCode.SetPlayerDirection(playerButtons, Direction.Left);
                         InputCode.SetPlayerDirection(playerButtons, Direction.Up);
+                        break;
+                }
+            }
+            else if (button.Button >= 32 && button.Button <= 44 && (direction == Direction.FFUp ||
+                                                                    direction == Direction.FFDown ||
+                                                                    direction == Direction.FFRight ||
+                                                                    direction == Direction.FFLeft ||
+                                                                    direction == Direction.FFHoriCenter ||
+                                                                    direction == Direction.FFVertCenter))
+            {
+                switch (state.Value)
+                {
+                    case -1:
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFHoriCenter);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFVertCenter);
+                        break;
+                    case 0:
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFUp);
+                        break;
+                    case 4500:
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFUp);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFRight);
+                        break;
+                    case 9000:
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFRight);
+                        break;
+                    case 13500:
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFDown);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFRight);
+                        break;
+                    case 18000:
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFDown);
+                        break;
+                    case 22500:
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFLeft);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFDown);
+                        break;
+                    case 27000:
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFLeft);
+                        break;
+                    case 31500:
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFLeft);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFUp);
                         break;
                 }
             }
@@ -583,34 +634,48 @@ namespace TeknoParrotUi.Common.InputProfiles.Helpers
                     case -1:
                         InputCode.SetPlayerDirection(playerButtons, Direction.HorizontalCenter);
                         InputCode.SetPlayerDirection(playerButtons, Direction.VerticalCenter);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFHoriCenter);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFVertCenter);
                         break;
                     case 0:
                         InputCode.SetPlayerDirection(playerButtons, Direction.Up);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFUp);
                         break;
                     case 4500:
                         InputCode.SetPlayerDirection(playerButtons, Direction.Up);
                         InputCode.SetPlayerDirection(playerButtons, Direction.Right);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFUp);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFRight);
                         break;
                     case 9000:
                         InputCode.SetPlayerDirection(playerButtons, Direction.Right);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFRight);
                         break;
                     case 13500:
                         InputCode.SetPlayerDirection(playerButtons, Direction.Down);
                         InputCode.SetPlayerDirection(playerButtons, Direction.Right);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFDown);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFRight);
                         break;
                     case 18000:
                         InputCode.SetPlayerDirection(playerButtons, Direction.Down);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFDown);
                         break;
                     case 22500:
                         InputCode.SetPlayerDirection(playerButtons, Direction.Left);
                         InputCode.SetPlayerDirection(playerButtons, Direction.Down);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFLeft);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFDown);
                         break;
                     case 27000:
                         InputCode.SetPlayerDirection(playerButtons, Direction.Left);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFLeft);
                         break;
                     case 31500:
                         InputCode.SetPlayerDirection(playerButtons, Direction.Left);
                         InputCode.SetPlayerDirection(playerButtons, Direction.Up);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFLeft);
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFUp);
                         break;
                 }
             }

--- a/TeknoParrotUi.Common/InputProfiles/Helpers/DigitalHelper.cs
+++ b/TeknoParrotUi.Common/InputProfiles/Helpers/DigitalHelper.cs
@@ -609,6 +609,14 @@ namespace TeknoParrotUi.Common.InputProfiles.Helpers
                         InputCode.SetPlayerDirection(playerButtons, Direction.VerticalCenter);
                     if (direction == Direction.Down && !playerButtons.UpPressed())
                         InputCode.SetPlayerDirection(playerButtons, Direction.VerticalCenter);
+                    if (direction == Direction.FFLeft && !playerButtons.FFRightPressed())
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFHoriCenter);
+                    if (direction == Direction.FFRight && !playerButtons.FFLeftPressed())
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFHoriCenter);
+                    if (direction == Direction.FFUp && !playerButtons.FFDownPressed())
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFVertCenter);
+                    if (direction == Direction.FFDown && !playerButtons.FFUpPressed())
+                        InputCode.SetPlayerDirection(playerButtons, Direction.FFVertCenter);
                 }
             }
         }

--- a/TeknoParrotUi.Common/InputProfiles/Helpers/DigitalHelper.cs
+++ b/TeknoParrotUi.Common/InputProfiles/Helpers/DigitalHelper.cs
@@ -331,13 +331,13 @@ namespace TeknoParrotUi.Common.InputProfiles.Helpers
                         InputCode.SetPlayerDirection(playerButtons, Direction.VerticalCenter);
                     if (direction == Direction.Down && !playerButtons.UpPressed())
                         InputCode.SetPlayerDirection(playerButtons, Direction.VerticalCenter);
-                    if (direction == Direction.FFLeft && !playerButtons.RightPressed())
+                    if (direction == Direction.FFLeft && !playerButtons.FFRightPressed())
+                       InputCode.SetPlayerDirection(playerButtons, Direction.FFHoriCenter);
+                    if (direction == Direction.FFRight && !playerButtons.FFLeftPressed())
                         InputCode.SetPlayerDirection(playerButtons, Direction.FFHoriCenter);
-                    if (direction == Direction.FFRight && !playerButtons.LeftPressed())
-                        InputCode.SetPlayerDirection(playerButtons, Direction.FFHoriCenter);
-                    if (direction == Direction.FFUp && !playerButtons.DownPressed())
+                    if (direction == Direction.FFUp && !playerButtons.FFDownPressed())
                         InputCode.SetPlayerDirection(playerButtons, Direction.FFVertCenter);
-                    if (direction == Direction.FFDown && !playerButtons.UpPressed())
+                    if (direction == Direction.FFDown && !playerButtons.FFUpPressed())
                         InputCode.SetPlayerDirection(playerButtons, Direction.FFVertCenter);
                 }
             }


### PR DESCRIPTION
When I originally got the other stick working, I only tested it with an analog stick on both XInput and DInput, rather then with a DPad. It now works with both analog and digital buttons, including the face buttons of a controller in theory (haven't tried using A B X Y for the right stick but have tried the DPad on my Xbox One controller and a generic USB controller)