### PR TITLE
Different titlebar for non-patreon on holidays, dark mode for non-patreon

### DIFF
--- a/TeknoParrotUi.Common/GameProfiles/HOTD4.xml
+++ b/TeknoParrotUi.Common/GameProfiles/HOTD4.xml
@@ -20,13 +20,13 @@
       <FieldValue>0</FieldValue>
       <FieldType>Bool</FieldType>
     </FieldInformation>
-	<FieldInformation>
+	  <FieldInformation>
       <CategoryName>General</CategoryName>
       <FieldName>CustomResolution</FieldName>
       <FieldValue>0</FieldValue>
       <FieldType>Bool</FieldType>
     </FieldInformation>
-	<FieldInformation>
+	  <FieldInformation>
       <CategoryName>General</CategoryName>
       <FieldName>ResolutionWidth</FieldName>
       <FieldValue>1280</FieldValue>

--- a/TeknoParrotUi.Common/GameProfiles/Rambo.xml
+++ b/TeknoParrotUi.Common/GameProfiles/Rambo.xml
@@ -28,13 +28,13 @@
       <FieldValue>0</FieldValue>
       <FieldType>Bool</FieldType>
     </FieldInformation>
-	<FieldInformation>
+	  <FieldInformation>
       <CategoryName>General</CategoryName>
       <FieldName>CustomResolution</FieldName>
       <FieldValue>0</FieldValue>
       <FieldType>Bool</FieldType>
     </FieldInformation>
-	<FieldInformation>
+	  <FieldInformation>
       <CategoryName>General</CategoryName>
       <FieldName>ResolutionWidth</FieldName>
       <FieldValue>1360</FieldValue>

--- a/TeknoParrotUi.Common/ParrotData.cs
+++ b/TeknoParrotUi.Common/ParrotData.cs
@@ -26,5 +26,6 @@ namespace TeknoParrotUi.Common
 
         public string UiColour { get; set; } = "lightblue";
         public bool UiDarkMode { get; set; } = false;
+        public bool UiHolidayThemes { get; set; } = true;
     }
 }

--- a/TeknoParrotUi/App.xaml.cs
+++ b/TeknoParrotUi/App.xaml.cs
@@ -110,23 +110,20 @@ namespace TeknoParrotUi
                 {
                     var now = DateTime.Now;
 
-                    // halloween - dark theme and orange title
+                    // halloween - orange title
                     if (now.Month == 10 && now.Day == 31)
                     {
-                        darkmode = true;
                         colourname = "orange";
                     }
 
-                    // christmas - light theme and red title
+                    // christmas - red title
                     if (now.Month == 12 && now.Day == 25)
                     {
-                        darkmode = false;
                         colourname = "red";
                     }
                 }
                 else
                 {
-                    darkmode = false;
                     colourname = "lightblue";
                 }
             }

--- a/TeknoParrotUi/App.xaml.cs
+++ b/TeknoParrotUi/App.xaml.cs
@@ -101,19 +101,44 @@ namespace TeknoParrotUi
             return $"pack://application:,,,/{input}";
         }
 
-        public static void LoadTheme(string colourname, bool darkmode)
+        public static void LoadTheme(string colourname, bool darkmode, bool holiday)
         {
-            // only change theme if patreon key exists.
-            if (IsPatreon())
+            // if user isn't patreon, use defaults
+            if (!IsPatreon())
             {
-                ph.SetLightDark(darkmode);
-                Debug.WriteLine($"UI colour: {colourname} | Dark mode: {darkmode}");
-                var colour = sp.Swatches.FirstOrDefault(a => a.Name == colourname);
-                if (colour != null)
+                if (holiday)
                 {
-                    ph.ReplacePrimaryColor(colour);
+                    var now = DateTime.Now;
+
+                    // halloween - dark theme and orange title
+                    if (now.Month == 10 && now.Day == 31)
+                    {
+                        darkmode = true;
+                        colourname = "orange";
+                    }
+
+                    // christmas - light theme and red title
+                    if (now.Month == 12 && now.Day == 25)
+                    {
+                        darkmode = false;
+                        colourname = "red";
+                    }
+                }
+                else
+                {
+                    darkmode = false;
+                    colourname = "lightblue";
                 }
             }
+
+            Debug.WriteLine($"UI colour: {colourname} | Dark mode: {darkmode}");
+
+            ph.SetLightDark(darkmode);
+            var colour = sp.Swatches.FirstOrDefault(a => a.Name == colourname);
+            if (colour != null)
+            {
+                ph.ReplacePrimaryColor(colour);
+            }     
         }
 
         public static bool IsPatreon()
@@ -205,7 +230,7 @@ namespace TeknoParrotUi
                 Source = new Uri(GetResourceString("MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml"))
             });
 
-            LoadTheme(Lazydata.ParrotData.UiColour, Lazydata.ParrotData.UiDarkMode);
+            LoadTheme(Lazydata.ParrotData.UiColour, Lazydata.ParrotData.UiDarkMode, Lazydata.ParrotData.UiHolidayThemes);
 
             if (Lazydata.ParrotData.UiDisableHardwareAcceleration)
                 RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;

--- a/TeknoParrotUi/UserControls/SettingsControl.xaml
+++ b/TeknoParrotUi/UserControls/SettingsControl.xaml
@@ -32,13 +32,13 @@
                     <CheckBox Name="ChkConfirmExit" HorizontalAlignment="Center" Content="Confirmation prompt on exit"/>
                     <CheckBox Name="ChkDownloadIcons" HorizontalAlignment="Center" Content="Download game icon when selected"/>
                     <CheckBox Name="ChkUiDisableHardwareAcceleration" HorizontalAlignment="Center" Content="Disable Hardware Acceleration in UI"/>
-                    <CheckBox Name="ChkUiHolidayThemes" HorizontalAlignment="Center" Content="Use a different theme on holidays"/>
+                    <CheckBox Name="ChkUiHolidayThemes" HorizontalAlignment="Center" Content="Use a different theme on holidays" Checked="ChkTheme_Checked" Unchecked="ChkTheme_Checked"/>
                     <Separator/>
                     <StackPanel Name="UiPatreon">
                         <Label Content="UI Customization (Patreon Only)" HorizontalAlignment="Center" FontSize="30"/>
                         <Label Content="UI Colour" HorizontalAlignment="Center" FontSize="15"/>
                         <ComboBox Name="UiColour" HorizontalAlignment="Center" SelectionChanged="UiColour_SelectionChanged"/>
-                        <CheckBox Name="ChkUiDarkMode" HorizontalAlignment="Center" Content="Dark Mode" Checked="ChkUiDarkMode_Checked" Unchecked="ChkUiDarkMode_Checked"/>
+                        <CheckBox Name="ChkUiDarkMode" HorizontalAlignment="Center" Content="Dark Mode" Checked="ChkTheme_Checked" Unchecked="ChkTheme_Checked"/>
                         <Separator/>
                     </StackPanel>
                     <CheckBox Margin="0,10,0,0" Name="ChkUseSto0ZCheckBox" Content="Enable sTo0z Zone" HorizontalAlignment="Center"/>

--- a/TeknoParrotUi/UserControls/SettingsControl.xaml
+++ b/TeknoParrotUi/UserControls/SettingsControl.xaml
@@ -32,6 +32,7 @@
                     <CheckBox Name="ChkConfirmExit" HorizontalAlignment="Center" Content="Confirmation prompt on exit"/>
                     <CheckBox Name="ChkDownloadIcons" HorizontalAlignment="Center" Content="Download game icon when selected"/>
                     <CheckBox Name="ChkUiDisableHardwareAcceleration" HorizontalAlignment="Center" Content="Disable Hardware Acceleration in UI"/>
+                    <CheckBox Name="ChkUiHolidayThemes" HorizontalAlignment="Center" Content="Use a different theme on holidays"/>
                     <Separator/>
                     <StackPanel Name="UiPatreon">
                         <Label Content="UI Customization (Patreon Only)" HorizontalAlignment="Center" FontSize="30"/>

--- a/TeknoParrotUi/UserControls/SettingsControl.xaml
+++ b/TeknoParrotUi/UserControls/SettingsControl.xaml
@@ -33,12 +33,12 @@
                     <CheckBox Name="ChkDownloadIcons" HorizontalAlignment="Center" Content="Download game icon when selected"/>
                     <CheckBox Name="ChkUiDisableHardwareAcceleration" HorizontalAlignment="Center" Content="Disable Hardware Acceleration in UI"/>
                     <CheckBox Name="ChkUiHolidayThemes" HorizontalAlignment="Center" Content="Use a different theme on holidays" Checked="ChkTheme_Checked" Unchecked="ChkTheme_Checked"/>
+                    <CheckBox Name="ChkUiDarkMode" HorizontalAlignment="Center" Content="Dark Mode" Checked="ChkTheme_Checked" Unchecked="ChkTheme_Checked"/>
                     <Separator/>
                     <StackPanel Name="UiPatreon">
                         <Label Content="UI Customization (Patreon Only)" HorizontalAlignment="Center" FontSize="30"/>
                         <Label Content="UI Colour" HorizontalAlignment="Center" FontSize="15"/>
                         <ComboBox Name="UiColour" HorizontalAlignment="Center" SelectionChanged="UiColour_SelectionChanged"/>
-                        <CheckBox Name="ChkUiDarkMode" HorizontalAlignment="Center" Content="Dark Mode" Checked="ChkTheme_Checked" Unchecked="ChkTheme_Checked"/>
                         <Separator/>
                     </StackPanel>
                     <CheckBox Margin="0,10,0,0" Name="ChkUseSto0ZCheckBox" Content="Enable sTo0z Zone" HorizontalAlignment="Center"/>

--- a/TeknoParrotUi/UserControls/SettingsControl.xaml.cs
+++ b/TeknoParrotUi/UserControls/SettingsControl.xaml.cs
@@ -165,12 +165,12 @@ namespace TeknoParrotUi.UserControls
         // reload theme
         private void UiColour_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            App.LoadTheme(UiColour.SelectedItem.ToString(), ChkUiDarkMode.IsChecked.Value);
+            App.LoadTheme(UiColour.SelectedItem.ToString(), ChkUiDarkMode.IsChecked.Value, ChkUiHolidayThemes.IsChecked.Value);
         }
 
-        private void ChkUiDarkMode_Checked(object sender, RoutedEventArgs e)
+        private void ChkTheme_Checked(object sender, RoutedEventArgs e)
         {
-            App.LoadTheme(UiColour.SelectedItem.ToString(), ChkUiDarkMode.IsChecked.Value);
+            App.LoadTheme(UiColour.SelectedItem.ToString(), ChkUiDarkMode.IsChecked.Value, ChkUiHolidayThemes.IsChecked.Value);
         }
     }
 }

--- a/TeknoParrotUi/UserControls/SettingsControl.xaml.cs
+++ b/TeknoParrotUi/UserControls/SettingsControl.xaml.cs
@@ -45,6 +45,7 @@ namespace TeknoParrotUi.UserControls
             UiColour.ItemsSource = new SwatchesProvider().Swatches.Select(a => a.Name).ToList();
             UiColour.SelectedItem = Lazydata.ParrotData.UiColour;
             ChkUiDarkMode.IsChecked = Lazydata.ParrotData.UiDarkMode;
+            ChkUiHolidayThemes.IsChecked = Lazydata.ParrotData.UiHolidayThemes;
 
             if (App.IsPatreon())
             {
@@ -119,6 +120,7 @@ namespace TeknoParrotUi.UserControls
                 
                 Lazydata.ParrotData.UiColour = UiColour.SelectedItem.ToString();
                 Lazydata.ParrotData.UiDarkMode = ChkUiDarkMode.IsChecked.Value;
+                Lazydata.ParrotData.UiHolidayThemes = ChkUiHolidayThemes.IsChecked.Value;
 
                 DiscordRPC.StartOrShutdown();
 


### PR DESCRIPTION
People were complaining about non-patreon not getting anything, so... 
Adds a option to use a different theme on holidays. Only works for non-patreon users, since patreon users can customize their theme.
Also allows non-patreon users to toggle dark mode
List of holidays (for now):
* Halloween (10/31) - orange title bar
* Christmas (12/25) - red title bar 