### PR TITLE
fixed star wars analog, as well as made a change to the automapper 

### DIFF
--- a/TeknoParrotUi.Common/GameProfiles/StarWars.xml
+++ b/TeknoParrotUi.Common/GameProfiles/StarWars.xml
@@ -7,7 +7,7 @@
   <ExtraParameters/>
   <TestMenuExtraParameters/>
   <IconName>Icons\StarWars.png</IconName>
-  <GameProfileRevision>13</GameProfileRevision>
+  <GameProfileRevision>14</GameProfileRevision>
   <Is64Bit>true</Is64Bit>
   <HasSeparateTestMode>false</HasSeparateTestMode>
   <EmulationProfile>NamcoMachStorm</EmulationProfile>
@@ -66,7 +66,7 @@
     <JoystickButtons>
       <ButtonName>Throttle</ButtonName>
       <InputMapping>Analog2</InputMapping>
-      <AnalogType>Gas</AnalogType>
+      <AnalogType>SWThrottle</AnalogType>
     </JoystickButtons>
     <JoystickButtons>
       <ButtonName>Analog X</ButtonName>

--- a/TeknoParrotUi.Common/InputListening/InputListenerDirectInput.cs
+++ b/TeknoParrotUi.Common/InputListening/InputListenerDirectInput.cs
@@ -914,6 +914,12 @@ namespace TeknoParrotUi.Common.InputListening
                     return gas;
 
                 }
+                case AnalogType.SWThrottle:
+                {
+                    var gas = HandleGasBrakeForJvs(state.Value, joystickButtons.DirectInputButton?.IsAxisMinus, true,
+                        true, false);
+                    return gas;
+                }
                 case AnalogType.Brake:
                 {
                     var brake = HandleGasBrakeForJvs(state.Value, joystickButtons.DirectInputButton?.IsAxisMinus, Lazydata.ParrotData.ReverseAxisGas, Lazydata.ParrotData.FullAxisGas, false);

--- a/TeknoParrotUi.Common/InputListening/InputListenerXInput.cs
+++ b/TeknoParrotUi.Common/InputListening/InputListenerXInput.cs
@@ -806,6 +806,8 @@ namespace TeknoParrotUi.Common.InputListening
                 case AnalogType.Gas:
                 case AnalogType.Brake:
                     return AnalogHelper.CalculateAxisOrTriggerGasBrakeXinput(joystickButtons.XInputButton, state);
+                case AnalogType.SWThrottle:
+                    return AnalogHelper.CalculateSWThrottleXinput(joystickButtons.XInputButton, state);
                 case AnalogType.Wheel:
                 {
                     var wheelPos = AnalogHelper.CalculateWheelPosXinput(joystickButtons.XInputButton, state, _useSto0Z, _stoozPercent, _gameProfile);

--- a/TeknoParrotUi.Common/InputProfiles/Helpers/AnalogHelper.cs
+++ b/TeknoParrotUi.Common/InputProfiles/Helpers/AnalogHelper.cs
@@ -6,6 +6,47 @@ namespace TeknoParrotUi.Common.InputProfiles.Helpers
 {
     public static class AnalogHelper
     {
+        public static byte CalculateSWThrottleXinput(XInputButton button, State state)
+        {
+            if (button.IsButton)
+            {
+                var btnPress = DigitalHelper.GetButtonPressXinput(button, state, 0);
+                if (btnPress == true)
+                    return 0xFF;
+                return 0x00;
+            }
+
+            if (button.IsLeftThumbX)
+            {
+                return JvsHelper.CalculateGasPos(state.Gamepad.LeftThumbX, false, false);
+            }
+
+            if (button.IsLeftThumbY)
+            {
+                return JvsHelper.CalculateGasPos(state.Gamepad.LeftThumbY, false, false);
+            }
+
+            if (button.IsRightThumbX)
+            {
+                return JvsHelper.CalculateGasPos(state.Gamepad.RightThumbX, false, false);
+            }
+
+            if (button.IsRightThumbY)
+            {
+                return JvsHelper.CalculateGasPos(state.Gamepad.RightThumbY, false, false);
+            }
+
+            if (button.IsLeftTrigger)
+            {
+                return state.Gamepad.LeftTrigger;
+            }
+
+            if (button.IsRightTrigger)
+            {
+                return state.Gamepad.RightTrigger;
+            }
+            return 0;
+        }
         public static byte CalculateAxisOrTriggerGasBrakeXinput(XInputButton button, State state)
         {
             if (button.IsButton)

--- a/TeknoParrotUi.Common/JoystickMapping.cs
+++ b/TeknoParrotUi.Common/JoystickMapping.cs
@@ -191,6 +191,7 @@ namespace TeknoParrotUi.Common
         None,
         Gas,
         Brake,
+        SWThrottle,
         Wheel,
         AnalogJoystick,
         AnalogJoystickReverse,

--- a/TeknoParrotUi/GameProfileLoader.cs
+++ b/TeknoParrotUi/GameProfileLoader.cs
@@ -54,8 +54,6 @@ namespace TeknoParrotUi.Common
                                 {
                                     button.DirectInputButton = other.JoystickButtons[i].DirectInputButton;
                                     button.XInputButton = other.JoystickButtons[i].XInputButton;
-                                    button.InputMapping = other.JoystickButtons[i].InputMapping;
-                                    button.AnalogType = other.JoystickButtons[i].AnalogType;
                                     button.BindNameDi = other.JoystickButtons[i].BindNameDi;
                                     button.BindNameXi = other.JoystickButtons[i].BindNameXi;
                                     button.BindName = other.JoystickButtons[i].BindName;


### PR DESCRIPTION
updated game profile automapper so that changes to analog type or button mapping don't get overwritten with old incorrect ones

its 3:30am here so if i've missed something or it somehow breaks (i tested with xbox one and ps4 controllers on both XInput and DInput) it is entirely possible