### PR TITLE
Fix game list focus

### DIFF
--- a/TeknoParrotUi/Views/AddGame.xaml.cs
+++ b/TeknoParrotUi/Views/AddGame.xaml.cs
@@ -86,7 +86,7 @@ namespace TeknoParrotUi.Views
 
             }
 
-            _library.ListUpdate(true);
+            _library.ListUpdate(_selected.GameName);
 
             _contentControl.Content = _library;
         }
@@ -110,7 +110,7 @@ namespace TeknoParrotUi.Views
                 // ignored
             }
 
-            _library.ListUpdate(true);
+            _library.ListUpdate();
 
             _contentControl.Content = _library;
         }


### PR DESCRIPTION
Switching pages does not reset your game list focus anymore.
So when changing settings or setting up controls the correct game keeps selected.