### PR TITLE
H2Overdrive controls FIX v2

### DIFF
--- a/TeknoParrotUi.Common/GameProfiles/H2Overdrive.xml
+++ b/TeknoParrotUi.Common/GameProfiles/H2Overdrive.xml
@@ -8,7 +8,7 @@
   <TestMenuExtraParameters/>
   <IconName>Icons\H2Overdrive.png</IconName>
   <EmulationProfile>RawThrillsFNFH2O</EmulationProfile>
-  <GameProfileRevision>3</GameProfileRevision>
+  <GameProfileRevision>4</GameProfileRevision>
   <HasSeparateTestMode>false</HasSeparateTestMode>
   <EmulatorType>OpenParrot</EmulatorType>
   <ExecutableName>sdaemon.exe</ExecutableName>
@@ -44,7 +44,7 @@
       <InputMapping>P1Button3</InputMapping>
     </JoystickButtons>
     <JoystickButtons>
-      <ButtonName>SERVICE</ButtonName>
+      <ButtonName>SERVICE / Menu Countdown Quickening</ButtonName>
       <InputMapping>P1Button4</InputMapping>
     </JoystickButtons>
     <JoystickButtons>


### PR DESCRIPTION
final control fix:
- view button in menu is NOT autofire anymore
- use SERVICE key to speed up the counter in menus