### PR TITLE
added FREEGLUT to hookedwindows for fullscreen usemouseforgun

### DIFF
--- a/TeknoParrotUi.Common/HookedWindows.txt
+++ b/TeknoParrotUi.Common/HookedWindows.txt
@@ -11,3 +11,4 @@ TeknoBudgie - Let's Go Jungle
 TeknoBudgie - 2Spicy
 TeknoBudgie - RAMBO
 VACUUM
+FREEGLUT


### PR DESCRIPTION
very epic, turns out you can't set the window title in glut if its fullscreen so it wasn't being hooked