### PR TITLE
SegaTools IDZ Support

### DIFF
--- a/TeknoParrotUi.Common/EmulationProfile.cs
+++ b/TeknoParrotUi.Common/EmulationProfile.cs
@@ -52,6 +52,7 @@
         RawThrillsFNFH2O,
         LostLandAdventuresPAL,
         GSEVO,
+        SegaToolsIDZ,
         //DO NOT USE, ONLY FOR MIGRATIONS!
         FNFDrift,
         GHA,

--- a/TeknoParrotUi.Common/EmulatorType.cs
+++ b/TeknoParrotUi.Common/EmulatorType.cs
@@ -18,5 +18,7 @@ namespace TeknoParrotUi.Common
         N2,
         //Open Source Konami
         OpenParrotKonami,
+        //SegaTools
+        SegaTools,
     }
 }

--- a/TeknoParrotUi.Common/GameProfiles/IDZ.xml
+++ b/TeknoParrotUi.Common/GameProfiles/IDZ.xml
@@ -1,0 +1,141 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<GameProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <GameName>Initial D: Arcade Stage Zero</GameName>
+  <GamePath/>
+  <TestMenuParameter>-t</TestMenuParameter>
+  <TestMenuIsExecutable>false</TestMenuIsExecutable>
+  <ExtraParameters/>
+  <TestMenuExtraParameters/>
+  <IconName>Icons\IDZ.png</IconName>
+  <EmulationProfile>SegaToolsIDZ</EmulationProfile>
+  <GameProfileRevision>0</GameProfileRevision>
+  <HasSeparateTestMode>true</HasSeparateTestMode>
+  <EmulatorType>SegaTools</EmulatorType>
+  <ConfigValues>
+    <FieldInformation>
+      <CategoryName>General</CategoryName>
+      <FieldName>XInput</FieldName>
+      <FieldValue>0</FieldValue>
+      <FieldType>Bool</FieldType>
+    </FieldInformation>
+    <FieldInformation>
+      <CategoryName>General</CategoryName>
+      <FieldName>NetworkAdapterIP</FieldName>
+      <FieldValue>0.0.0.0</FieldValue>
+      <FieldType>Text</FieldType>
+    </FieldInformation>
+    <FieldInformation>
+      <CategoryName>General</CategoryName>
+      <FieldName>ExportRegion</FieldName>
+      <FieldValue>true</FieldValue>
+      <FieldType>Bool</FieldType>
+    </FieldInformation>
+    <FieldInformation>
+      <CategoryName>General</CategoryName>
+      <FieldName>WheelRestriction</FieldName>
+      <FieldValue>97</FieldValue>
+      <FieldType>Text</FieldType>
+    </FieldInformation>
+    <FieldInformation>
+      <CategoryName>General</CategoryName>
+      <FieldName>EnableNetenv</FieldName>
+      <FieldValue>true</FieldValue>
+      <FieldType>Bool</FieldType>
+    </FieldInformation>
+    <FieldInformation>
+      <CategoryName>General</CategoryName>
+      <FieldName>EnableDistServ</FieldName>
+      <FieldValue>true</FieldValue>
+      <FieldType>Bool</FieldType>
+    </FieldInformation>
+  </ConfigValues>
+  <JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Test</ButtonName>
+      <InputMapping>Test</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Service</ButtonName>
+      <InputMapping>Service1</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Coin</ButtonName>
+      <InputMapping>Coin1</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Insert AIME Card</ButtonName>
+      <InputMapping>ExtensionOne13</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Start</ButtonName>
+      <InputMapping>P1ButtonStart</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Wheel Axis</ButtonName>
+      <InputMapping>Analog0</InputMapping>
+      <AnalogType>Wheel</AnalogType>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Gas</ButtonName>
+      <InputMapping>Analog2</InputMapping>
+      <AnalogType>Gas</AnalogType>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Brake</ButtonName>
+      <InputMapping>Analog4</InputMapping>
+      <AnalogType>Brake</AnalogType>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Shift up</ButtonName>
+      <InputMapping>P2ButtonUp</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Shift Down</ButtonName>
+      <InputMapping>P2ButtonDown</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>View Change</ButtonName>
+      <InputMapping>P1Button1</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Menu Up</ButtonName>
+      <InputMapping>P1ButtonUp</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Menu Down</ButtonName>
+      <InputMapping>P1ButtonDown</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Menu Left</ButtonName>
+      <InputMapping>P1ButtonLeft</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>Menu Right</ButtonName>
+      <InputMapping>P1ButtonRight</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>1st Gear</ButtonName>
+      <InputMapping>ExtensionOne1</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>2nd Gear</ButtonName>
+      <InputMapping>ExtensionOne2</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>3rd Gear</ButtonName>
+      <InputMapping>ExtensionOne3</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>4th Gear</ButtonName>
+      <InputMapping>ExtensionOne4</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>5th Gear</ButtonName>
+      <InputMapping>ExtensionOne11</InputMapping>
+    </JoystickButtons>
+    <JoystickButtons>
+      <ButtonName>6th Gear</ButtonName>
+      <InputMapping>ExtensionOne12</InputMapping>
+    </JoystickButtons>
+  </JoystickButtons>
+</GameProfile>

--- a/TeknoParrotUi.Common/GameProfiles/IDZ.xml
+++ b/TeknoParrotUi.Common/GameProfiles/IDZ.xml
@@ -7,8 +7,9 @@
   <ExtraParameters/>
   <TestMenuExtraParameters/>
   <IconName>Icons\IDZ.png</IconName>
+  <Is64Bit>true</Is64Bit>
   <EmulationProfile>SegaToolsIDZ</EmulationProfile>
-  <GameProfileRevision>0</GameProfileRevision>
+  <GameProfileRevision>1</GameProfileRevision>
   <HasSeparateTestMode>true</HasSeparateTestMode>
   <EmulatorType>SegaTools</EmulatorType>
   <ConfigValues>

--- a/TeknoParrotUi.Common/Pipes/SegaTools.cs
+++ b/TeknoParrotUi.Common/Pipes/SegaTools.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TeknoParrotUi.Common.Jvs;
+
+namespace TeknoParrotUi.Common.Pipes
+{
+    public class SegaTools : ControlSender
+    {
+        private bool _combineGasBrake;
+        public SegaTools(bool combineGasBrake)
+        {
+            _combineGasBrake = combineGasBrake;
+        }
+        public override void Transmit()
+        {
+            // Start
+            if (InputCode.PlayerDigitalButtons[0].Start.HasValue && InputCode.PlayerDigitalButtons[0].Start.Value)
+                Control |= 0x01;
+
+            // D-Pad
+            // Up
+            if (InputCode.PlayerDigitalButtons[0].Up.HasValue && InputCode.PlayerDigitalButtons[0].Up.Value)
+                Control |= 0x02;
+            // Down
+            if (InputCode.PlayerDigitalButtons[0].Down.HasValue && InputCode.PlayerDigitalButtons[0].Down.Value)
+                Control |= 0x04;
+            // Left
+            if (InputCode.PlayerDigitalButtons[0].Left.HasValue && InputCode.PlayerDigitalButtons[0].Left.Value)
+                Control |= 0x08;
+            // Right
+            if (InputCode.PlayerDigitalButtons[0].Right.HasValue && InputCode.PlayerDigitalButtons[0].Right.Value)
+                Control |= 0x10;
+
+            // Shifter
+            // Shift Up
+            if (InputCode.PlayerDigitalButtons[1].Up.HasValue && InputCode.PlayerDigitalButtons[1].Up.Value)
+                Control |= 0x20;
+            // Shift Down
+            if (InputCode.PlayerDigitalButtons[1].Down.HasValue && InputCode.PlayerDigitalButtons[1].Down.Value)
+                Control |= 0x0100;
+
+            // View Change
+            if (InputCode.PlayerDigitalButtons[0].Button1.HasValue && InputCode.PlayerDigitalButtons[0].Button1.Value)
+                Control |= 0x0200;
+
+            // 1st Gear
+            if (InputCode.PlayerDigitalButtons[0].ExtensionButton1.HasValue && InputCode.PlayerDigitalButtons[0].ExtensionButton1.Value)
+                Control |= 0x0400;
+            // 2nd Gear
+            if (InputCode.PlayerDigitalButtons[0].ExtensionButton2.HasValue && InputCode.PlayerDigitalButtons[0].ExtensionButton2.Value)
+                Control |= 0x0800;
+            // 3rd Gear
+            if (InputCode.PlayerDigitalButtons[0].ExtensionButton3.HasValue && InputCode.PlayerDigitalButtons[0].ExtensionButton3.Value)
+                Control |= 0x1000;
+            // 4th Gear
+            if (InputCode.PlayerDigitalButtons[0].ExtensionButton4.HasValue && InputCode.PlayerDigitalButtons[0].ExtensionButton4.Value)
+                Control |= 0x2000;
+            // 5th Gear
+            if (InputCode.PlayerDigitalButtons[0].ExtensionButton1_1.HasValue && InputCode.PlayerDigitalButtons[0].ExtensionButton1_1.Value)
+                Control |= 0x4000;
+            // 6th Gear
+            if (InputCode.PlayerDigitalButtons[0].ExtensionButton1_2.HasValue && InputCode.PlayerDigitalButtons[0].ExtensionButton1_2.Value)
+                Control |= 0x8000;
+            // Test
+            if (InputCode.PlayerDigitalButtons[0].Test.HasValue && InputCode.PlayerDigitalButtons[0].Test.Value)
+                Control |= 0x010000;
+            // Service
+            if (InputCode.PlayerDigitalButtons[0].Service.HasValue && InputCode.PlayerDigitalButtons[0].Service.Value)
+                Control |= 0x020000;
+            // Coin
+            if (InputCode.PlayerDigitalButtons[0].Coin.HasValue && InputCode.PlayerDigitalButtons[0].Coin.Value)
+                Control |= 0x040000;
+            // Insert AIME
+            if (InputCode.PlayerDigitalButtons[0].ExtensionButton1_3.HasValue && InputCode.PlayerDigitalButtons[0].ExtensionButton1_3.Value)
+                Control |= 0x080000;
+
+   
+            JvsHelper.StateView.Write(8, Control);
+            JvsHelper.StateView.Write(12, InputCode.AnalogBytes[0]);
+            if (_combineGasBrake)
+            {
+                if (InputCode.AnalogBytes[4] > 0x00)
+                {
+                    JvsHelper.StateView.Write(16, 0 - InputCode.AnalogBytes[4]);
+                    JvsHelper.StateView.Write(20, 0);
+                }
+                else if (InputCode.AnalogBytes[2] > 0x00)
+                {
+                    JvsHelper.StateView.Write(16, 0 + InputCode.AnalogBytes[2]);
+                    JvsHelper.StateView.Write(20, 0);
+                }
+                else
+                {
+                    JvsHelper.StateView.Write(16, 0);
+                    JvsHelper.StateView.Write(20, 0);
+                }
+            }
+            else
+            {
+                JvsHelper.StateView.Write(16, InputCode.AnalogBytes[2]);
+                JvsHelper.StateView.Write(20, InputCode.AnalogBytes[4]);
+            }
+        }
+    }
+}

--- a/TeknoParrotUi.Common/TeknoParrotUi.Common.csproj
+++ b/TeknoParrotUi.Common/TeknoParrotUi.Common.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Jvs\JvsPackageEmulator.cs" />
     <Compile Include="Pipes\RawThrills.cs" />
     <Compile Include="Pipes\SegaRallyPipe.cs" />
+    <Compile Include="Pipes\SegaTools.cs" />
     <Compile Include="RawInputListener.cs" />
     <Compile Include="SerialPortHandler.cs" />
     <Compile Include="ParrotData.cs" />
@@ -128,6 +129,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="GameProfiles\*.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="GameProfiles\IDZ.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="HookedWindows.txt">

--- a/TeknoParrotUi/MainWindow.xaml.cs
+++ b/TeknoParrotUi/MainWindow.xaml.cs
@@ -233,7 +233,10 @@ namespace TeknoParrotUi
             public bool opensource { get; set; } = true;
             // if set, the updater will extract the files into this folder rather than the name folder
             public string folderOverride { get; set; }
-            public string fullUrl { get { return "https://github.com/teknogods/" + (!string.IsNullOrEmpty(reponame) ? reponame : name) + "/"; } }
+            // if set, it will grab the update from a specific github user's account, if not set it'll use teknogods
+            public string userName { get; set; }
+            public string fullUrl { get { return "https://github.com/" + (!string.IsNullOrEmpty(userName) ? userName : "teknogods") + "/" + (!string.IsNullOrEmpty(reponame) ? reponame : name) + "/"; }
+            }
             // local version number
             public string _localVersion;
             public string localVersion
@@ -297,6 +300,14 @@ namespace TeknoParrotUi
                 opensource = false,
                 folderOverride = "N2"
             },
+            new UpdaterComponent
+            {
+                name = "SegaTools",
+                location = Path.Combine("SegaTools", "idzhook.dll"),
+                reponame = "SegaToolsTP",
+                folderOverride = "SegaTools",
+                userName = "nzgamer41"
+            },
         };
 
         async Task<GithubRelease> GetGithubRelease(UpdaterComponent component)
@@ -314,7 +325,7 @@ namespace TeknoParrotUi
                 //Github's API requires a user agent header, it'll 403 without it
                 client.DefaultRequestHeaders.Add("User-Agent", "TeknoParrot");
                 var reponame = !string.IsNullOrEmpty(component.reponame) ? component.reponame : component.name;
-                var url = $"https://api.github.com/repos/TeknoGods/{reponame}/releases/tags/{component.name}{secret}";
+                var url = $"https://api.github.com/repos/{(!string.IsNullOrEmpty(component.userName) ? component.userName : "teknogods")}/{reponame}/releases/tags/{component.name}{secret}";
                 Debug.WriteLine($"Updater url for {component.name}: {url}");
                 var response = await client.GetAsync(url);
                 if (response.IsSuccessStatusCode)

--- a/TeknoParrotUi/TeknoParrotUi.csproj
+++ b/TeknoParrotUi/TeknoParrotUi.csproj
@@ -146,6 +146,21 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="Xceed.Wpf.AvalonDock, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
+    </Reference>
+    <Reference Include="Xceed.Wpf.Toolkit, Version=3.8.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.8.1\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/TeknoParrotUi/Views/GameRunning.xaml.cs
+++ b/TeknoParrotUi/Views/GameRunning.xaml.cs
@@ -753,7 +753,7 @@ namespace TeknoParrotUi.Views
         }
 
         // IDZ specific stuff, should probably be replaced
-        // It's ZeroLauncher code that I give full permission to be used here - nzgamer
+        // It's ZeroLauncher code that I give full permission to be used here, now people can't have a cry "reeee stole code" - nzgamer
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         static extern bool AllocConsole();
@@ -956,7 +956,8 @@ namespace TeknoParrotUi.Views
                     //check for DEVICE folder
                     if (Directory.Exists(gameDir + "\\DEVICE"))
                     {
-                        //ok no need to create that
+                        File.Copy(".\\SegaTools\\DEVICE\\billing.pub", gameDir + "\\DEVICE\\billing.pub",true);
+                        File.Copy(".\\SegaTools\\DEVICE\\ca.crt", gameDir + "\\DEVICE\\ca.crt",true);
                     }
                     else
                     {

--- a/TeknoParrotUi/Views/Library.xaml.cs
+++ b/TeknoParrotUi/Views/Library.xaml.cs
@@ -275,6 +275,14 @@ namespace TeknoParrotUi.Views
                 case EmulatorType.OpenParrotKonami:
                     loaderExe = ".\\OpenParrotWin32\\OpenParrotKonamiLoader.exe";
                     break;
+                case EmulatorType.SegaTools:
+                    File.Copy(".\\SegaTools\\aimeio.dll", Path.GetDirectoryName(gameProfile.GamePath) + "\\aimeio.dll", true);
+                    File.Copy(".\\SegaTools\\idzhook.dll", Path.GetDirectoryName(gameProfile.GamePath) + "\\idzhook.dll", true);
+                    File.Copy(".\\SegaTools\\idzio.dll", Path.GetDirectoryName(gameProfile.GamePath) + "\\idzio.dll", true);
+                    File.Copy(".\\SegaTools\\inject.exe", Path.GetDirectoryName(gameProfile.GamePath) + "\\inject.exe", true);
+                    loaderExe = ".\\SegaTools\\inject.exe";
+                    loaderDll = Path.GetDirectoryName(gameProfile.GamePath) + "\\idzhook";
+                    break;
                 default:
                     loaderDll = (gameProfile.Is64Bit ? ".\\TeknoParrot\\TeknoParrot64" : ".\\TeknoParrot\\TeknoParrot");
                     break;


### PR DESCRIPTION
This adds the ability to play IDZ using SegaTools while having TeknoParrotUI handle the controls. This means you can remap XInput controls, as well as the keyboard is not needed for ANY controls, not even inserting an AIME card. Works in tangent with my modified version of SegaTools, located at https://github.com/nzgamer41/SegaToolsTP