### PR TITLE
Proper coin input handling for JVS.

### DIFF
--- a/TeknoParrotUi.Common/GameProfiles/TetrisTheGrandMaster3TerrorInstinct.xml
+++ b/TeknoParrotUi.Common/GameProfiles/TetrisTheGrandMaster3TerrorInstinct.xml
@@ -8,7 +8,7 @@
   <TestMenuExtraParameters/>
   <IconName>Icons\TetrisTheGrandMaster3TerrorInstinct.png</IconName>
   <EmulationProfile>TaitoTypeXGeneric</EmulationProfile>
-  <GameProfileRevision>5</GameProfileRevision>
+  <GameProfileRevision>6</GameProfileRevision>
   <HasSeparateTestMode>false</HasSeparateTestMode>
   <EmulatorType>OpenParrot</EmulatorType>
   <ConfigValues>
@@ -24,6 +24,17 @@
       <FieldValue>1</FieldValue>
       <FieldType>Bool</FieldType>
     </FieldInformation>
+     <FieldInformation>
+      <CategoryName>General</CategoryName>
+      <FieldName>ResolutionWidth</FieldName>
+      <FieldValue>640</FieldValue>
+      <FieldType>Text</FieldType>
+    </FieldInformation>
+    <FieldInformation>
+      <CategoryName>General</CategoryName>
+      <FieldName>ResolutionHeight</FieldName>
+      <FieldValue>480</FieldValue>
+      <FieldType>Text</FieldType>
   </ConfigValues>
   <JoystickButtons>
     <JoystickButtons>

--- a/TeknoParrotUi.Common/GameProfiles/TetrisTheGrandMaster3TerrorInstinct.xml
+++ b/TeknoParrotUi.Common/GameProfiles/TetrisTheGrandMaster3TerrorInstinct.xml
@@ -24,7 +24,7 @@
       <FieldValue>1</FieldValue>
       <FieldType>Bool</FieldType>
     </FieldInformation>
-     <FieldInformation>
+    <FieldInformation>
       <CategoryName>General</CategoryName>
       <FieldName>ResolutionWidth</FieldName>
       <FieldValue>640</FieldValue>
@@ -35,6 +35,7 @@
       <FieldName>ResolutionHeight</FieldName>
       <FieldValue>480</FieldValue>
       <FieldType>Text</FieldType>
+    <FieldInformation>
   </ConfigValues>
   <JoystickButtons>
     <JoystickButtons>

--- a/TeknoParrotUi.Common/InputListening/InputListenerDirectInput.cs
+++ b/TeknoParrotUi.Common/InputListening/InputListenerDirectInput.cs
@@ -496,7 +496,7 @@ namespace TeknoParrotUi.Common.InputListening
                         &&(JvsPackageEmulator.CoinStates[2] != (bool)InputCode.PlayerDigitalButtons[2].Coin)) // and the state changed
                     {
                         // update state to match the switch
-                        JvsPackageEmulator.CoinStates[2] = (bool)InputCode.PlayerDigitalButtons[0].Coin;
+                        JvsPackageEmulator.CoinStates[2] = (bool)InputCode.PlayerDigitalButtons[2].Coin;
                         if (JvsPackageEmulator.CoinStates[2]==false) // and if the button was just released
                         {
                             JvsPackageEmulator.Coins[2]++; // increment the coin counnter
@@ -507,10 +507,10 @@ namespace TeknoParrotUi.Common.InputListening
                     InputCode.PlayerDigitalButtons[3].Coin = DigitalHelper.GetButtonPressDirectInput(button, state);
                     // we need to update the coin counter HERE.
                     if ((InputCode.PlayerDigitalButtons[3].Coin != null)  // if not null
-                        &&(JvsPackageEmulator.CoinStates[3] != (bool)InputCode.PlayerDigitalButtons[0].Coin)) // and the state changed
+                        &&(JvsPackageEmulator.CoinStates[3] != (bool)InputCode.PlayerDigitalButtons[3].Coin)) // and the state changed
                     {
                         // update state to match the switch
-                        JvsPackageEmulator.CoinStates[3] = (bool)InputCode.PlayerDigitalButtons[0].Coin;
+                        JvsPackageEmulator.CoinStates[3] = (bool)InputCode.PlayerDigitalButtons[3].Coin;
                         if (JvsPackageEmulator.CoinStates[3]==false) // and if the button was just released
                         {
                             JvsPackageEmulator.Coins[3]++; // increment the coin counnter

--- a/TeknoParrotUi.Common/InputListening/InputListenerDirectInput.cs
+++ b/TeknoParrotUi.Common/InputListening/InputListenerDirectInput.cs
@@ -155,9 +155,31 @@ namespace TeknoParrotUi.Common.InputListening
                     break;
                 case InputMapping.Coin1:
                     InputCode.PlayerDigitalButtons[0].Coin = DigitalHelper.GetButtonPressDirectInput(button, state);
+                    // we need to update the coin counter HERE.
+                    if ((InputCode.PlayerDigitalButtons[0].Coin != null)  // if not null
+                        &&(JvsPackageEmulator.CoinStates[0] != (bool)InputCode.PlayerDigitalButtons[0].Coin)) // and the state changed
+                    {
+                        // update state to match the switch
+                        JvsPackageEmulator.CoinStates[0] = (bool)InputCode.PlayerDigitalButtons[0].Coin;
+                        if (JvsPackageEmulator.CoinStates[0]==false) // and if the button was just released
+                        {
+                            JvsPackageEmulator.Coins[0]++; // increment the coin counnter
+                        }
+                    }
                     break;
                 case InputMapping.Coin2:
                     InputCode.PlayerDigitalButtons[1].Coin = DigitalHelper.GetButtonPressDirectInput(button, state);
+                    // we need to update the coin counter HERE.
+                    if ((InputCode.PlayerDigitalButtons[1].Coin != null)  // if not null
+                        &&(JvsPackageEmulator.CoinStates[1] != (bool)InputCode.PlayerDigitalButtons[1].Coin)) // and the state changed
+                    {
+                        // update state to match the switch
+                        JvsPackageEmulator.CoinStates[1] = (bool)InputCode.PlayerDigitalButtons[1].Coin;
+                        if (JvsPackageEmulator.CoinStates[1]==false) // and if the button was just released
+                        {
+                            JvsPackageEmulator.Coins[1]++; // increment the coin counnter
+                        }
+                    }
                     break;
                 case InputMapping.P1Button1:
                     if (_gameProfile.EmulationProfile == EmulationProfile.Theatrhythm)
@@ -469,9 +491,31 @@ namespace TeknoParrotUi.Common.InputListening
                     break;
                 case InputMapping.JvsTwoCoin1:
                     InputCode.PlayerDigitalButtons[2].Coin = DigitalHelper.GetButtonPressDirectInput(button, state);
+                    // we need to update the coin counter HERE.
+                    if ((InputCode.PlayerDigitalButtons[2].Coin != null)  // if not null
+                        &&(JvsPackageEmulator.CoinStates[2] != (bool)InputCode.PlayerDigitalButtons[2].Coin)) // and the state changed
+                    {
+                        // update state to match the switch
+                        JvsPackageEmulator.CoinStates[2] = (bool)InputCode.PlayerDigitalButtons[0].Coin;
+                        if (JvsPackageEmulator.CoinStates[2]==false) // and if the button was just released
+                        {
+                            JvsPackageEmulator.Coins[2]++; // increment the coin counnter
+                        }
+                    }
                     break;
                 case InputMapping.JvsTwoCoin2:
                     InputCode.PlayerDigitalButtons[3].Coin = DigitalHelper.GetButtonPressDirectInput(button, state);
+                    // we need to update the coin counter HERE.
+                    if ((InputCode.PlayerDigitalButtons[3].Coin != null)  // if not null
+                        &&(JvsPackageEmulator.CoinStates[3] != (bool)InputCode.PlayerDigitalButtons[0].Coin)) // and the state changed
+                    {
+                        // update state to match the switch
+                        JvsPackageEmulator.CoinStates[3] = (bool)InputCode.PlayerDigitalButtons[0].Coin;
+                        if (JvsPackageEmulator.CoinStates[3]==false) // and if the button was just released
+                        {
+                            JvsPackageEmulator.Coins[3]++; // increment the coin counnter
+                        }
+                    }
                     break;
                 case InputMapping.JvsTwoP1Button1:
                     InputCode.PlayerDigitalButtons[2].Button1 = DigitalHelper.GetButtonPressDirectInput(button, state);

--- a/TeknoParrotUi.Common/InputListening/InputListenerXInput.cs
+++ b/TeknoParrotUi.Common/InputListening/InputListenerXInput.cs
@@ -97,9 +97,31 @@ namespace TeknoParrotUi.Common.InputListening
                     break;
                 case InputMapping.Coin1:
                     InputCode.PlayerDigitalButtons[0].Coin = DigitalHelper.GetButtonPressXinput(button, state, index);
+                    // we need to update the coin counter HERE.
+                    if ((InputCode.PlayerDigitalButtons[0].Coin != null)  // if not null
+                        &&(JvsPackageEmulator.CoinStates[0] != (bool)InputCode.PlayerDigitalButtons[0].Coin)) // and the state changed
+                    {
+                        // update state to match the switch
+                        JvsPackageEmulator.CoinStates[0] = (bool)InputCode.PlayerDigitalButtons[0].Coin;
+                        if (JvsPackageEmulator.CoinStates[0]==false) // and if the button was just released
+                        {
+                            JvsPackageEmulator.Coins[0]++; // increment the coin counnter
+                        }
+                    }
                     break;
                 case InputMapping.Coin2:
                     InputCode.PlayerDigitalButtons[1].Coin = DigitalHelper.GetButtonPressXinput(button, state, index);
+                    // we need to update the coin counter HERE.
+                    if ((InputCode.PlayerDigitalButtons[1].Coin != null)  // if not null
+                        &&(JvsPackageEmulator.CoinStates[1] != (bool)InputCode.PlayerDigitalButtons[1].Coin)) // and the state changed
+                    {
+                        // update state to match the switch
+                        JvsPackageEmulator.CoinStates[1] = (bool)InputCode.PlayerDigitalButtons[1].Coin;
+                        if (JvsPackageEmulator.CoinStates[1]==false) // and if the button was just released
+                        {
+                            JvsPackageEmulator.Coins[1]++; // increment the coin counnter
+                        }
+                    }
                     break;
                 case InputMapping.P1Button1:
                     if (_gameProfile.EmulationProfile == EmulationProfile.Theatrhythm)
@@ -373,9 +395,31 @@ namespace TeknoParrotUi.Common.InputListening
                     break;
                 case InputMapping.JvsTwoCoin1:
                     InputCode.PlayerDigitalButtons[2].Coin = DigitalHelper.GetButtonPressXinput(button, state, index);
+                    // we need to update the coin counter HERE.
+                    if ((InputCode.PlayerDigitalButtons[2].Coin != null)  // if not null
+                        &&(JvsPackageEmulator.CoinStates[2] != (bool)InputCode.PlayerDigitalButtons[2].Coin)) // and the state changed
+                    {
+                        // update state to match the switch
+                        JvsPackageEmulator.CoinStates[2] = (bool)InputCode.PlayerDigitalButtons[2].Coin;
+                        if (JvsPackageEmulator.CoinStates[2]==false) // and if the button was just released
+                        {
+                            JvsPackageEmulator.Coins[2]++; // increment the coin counnter
+                        }
+                    }                    
                     break;
                 case InputMapping.JvsTwoCoin2:
                     InputCode.PlayerDigitalButtons[3].Coin = DigitalHelper.GetButtonPressXinput(button, state, index);
+                    // we need to update the coin counter HERE.
+                    if ((InputCode.PlayerDigitalButtons[3].Coin != null)  // if not null
+                        &&(JvsPackageEmulator.CoinStates[3] != (bool)InputCode.PlayerDigitalButtons[3].Coin)) // and the state changed
+                    {
+                        // update state to match the switch
+                        JvsPackageEmulator.CoinStates[3] = (bool)InputCode.PlayerDigitalButtons[0].Coin;
+                        if (JvsPackageEmulator.CoinStates[3]==false) // and if the button was just released
+                        {
+                            JvsPackageEmulator.Coins[3]++; // increment the coin counnter
+                        }
+                    }
                     break;
                 case InputMapping.JvsTwoP1Button1:
                     InputCode.PlayerDigitalButtons[2].Button1 = DigitalHelper.GetButtonPressXinput(button, state, index);

--- a/TeknoParrotUi.Common/Jvs/JvsPackageEmulator.cs
+++ b/TeknoParrotUi.Common/Jvs/JvsPackageEmulator.cs
@@ -492,7 +492,7 @@ namespace TeknoParrotUi.Common.Jvs
 
             var coinSlot = bytesLeft[1];
             var coinCount = (bytesLeft[2] << 8) | bytesLeft[3];
-            coinslot--; // jvs slot numers start at 1, but we start at zero.
+            coinSlot--; // jvs slot numers start at 1, but we start at zero.
                         // TODO: handle dual board properly.
             Coins[coinSlot] -= coinCount;
 

--- a/TeknoParrotUi.Common/Jvs/JvsPackageEmulator.cs
+++ b/TeknoParrotUi.Common/Jvs/JvsPackageEmulator.cs
@@ -23,8 +23,8 @@ namespace TeknoParrotUi.Common.Jvs
         public static string JvsIdentifier;
         public static bool Namco;
 
-        private static readonly int[] Coins = new int[4];
-        private static readonly bool[] CoinStates = new bool[4];
+        public static int[] Coins = new int[4];           // need to be able to change this directly from input handlers
+        public static bool[] CoinStates = new bool[4];    // and we need this to detect changes.
 
         public static bool Taito;
         public static bool TaitoStick;

--- a/TeknoParrotUi.Common/Jvs/JvsPackageEmulator.cs
+++ b/TeknoParrotUi.Common/Jvs/JvsPackageEmulator.cs
@@ -492,7 +492,8 @@ namespace TeknoParrotUi.Common.Jvs
 
             var coinSlot = bytesLeft[1];
             var coinCount = (bytesLeft[2] << 8) | bytesLeft[3];
-
+            coinslot--; // jvs slot numers start at 1, but we start at zero.
+                        // TODO: handle dual board properly.
             Coins[coinSlot] -= coinCount;
 
             if (Coins[coinSlot] < 0)
@@ -761,49 +762,16 @@ namespace TeknoParrotUi.Common.Jvs
             reply.LengthReduction = 2;
 
             var byteLst = new List<byte>();
-
-            if (InputCode.PlayerDigitalButtons[0].Coin.HasValue && InputCode.PlayerDigitalButtons[0].Coin.Value)
-            {
-                if (!CoinStates[0])
-                {
-                    Coins[0] = 1;
-                    CoinStates[0] = true;
-                }
-                else
-                {
-                    Coins[0] = 0;
-                }
-            }
-            else
-            {
-                Coins[0] = 0;
-                CoinStates[0] = false;
-            }
-
-            if (InputCode.PlayerDigitalButtons[1].Coin.HasValue && InputCode.PlayerDigitalButtons[1].Coin.Value)
-            {
-                if (!CoinStates[1])
-                {
-                    Coins[1] = 1;
-                    CoinStates[1] = true;
-                }
-                else
-                {
-                    Coins[1] = 0;
-                }
-            }
-            else
-            {
-                Coins[1] = 0;
-                CoinStates[1] = false;
-            }
+            // no longer need to mess with Coin and CoinStates here
 
             if (multiPackage)
                 byteLst.Add(0x01);
 
             for (int i = 0; i < slotCount; i++)
             {
-                byteLst.Add((byte)(Coins[i] >> 8));
+                byteLst.Add((byte)(Coins[i] >> 8)); // we are ignoring the actual CoinStates here, and saying things are normal 
+                                                    // technically we should apply the proper OR mask based on CoinStates[i]
+                                                    // here, but those only ever happen with actual arcades. :)
                 byteLst.Add((byte)(Coins[i] & 0xFF));
             }
 


### PR DESCRIPTION
This fixes super street fighter iv AE, and probably many others.

The JVS I/O board stores coins totals that haven't been acknowledged by the arcade independently from any actual communication.

These changes replicate that behavior.  This is untested with coin inputs on second board from dual jvs, because no game maps it yet. :)

oh, and here's the new game profile for TGM3 too, with resolution for when that patch gets in.