### PR TITLE
Adding prefix to game list to identify already added game profiles.

### DIFF
--- a/TeknoParrotUi/Views/AddGame.xaml.cs
+++ b/TeknoParrotUi/Views/AddGame.xaml.cs
@@ -40,10 +40,20 @@ namespace TeknoParrotUi.Views
                 // 64-bit game on non-64 bit OS
                 var disabled = (gameProfile.Is64Bit && !Environment.Is64BitOperatingSystem);
                 var thirdparty = gameProfile.EmulatorType == EmulatorType.SegaTools;
+                var existing = false;
+
+                // check the existing user profiles
+                foreach (var gameProfile2 in GameProfileLoader.UserProfiles)
+                {
+                    if (gameProfile.GameName == gameProfile2.GameName) {
+                        existing = true;
+                        break;
+                    }
+                }
 
                 var item = new ListBoxItem
                 {
-                    Content = gameProfile.GameName + (gameProfile.Patreon ? " (Patreon)" : string.Empty) + (disabled ? " (64-bit)" : string.Empty) + (thirdparty ? $" (Third-Party - {gameProfile.EmulatorType})" : string.Empty),
+                    Content = (existing ? "- " : "+ ") + gameProfile.GameName + (gameProfile.Patreon ? " (Patreon)" : string.Empty) + (disabled ? " (64-bit)" : string.Empty) + (thirdparty ? $" (Third-Party - {gameProfile.EmulatorType})" : string.Empty),
                     Tag = gameProfile
                 };
 


### PR DESCRIPTION
This (untested) change, should identify games that have already been added to your library. Games not in your library will show a plus (+) and games already in your library will show a minus (-).