### PR TITLE
Adding Portable Mode to UI main settings for future use.

### DIFF
--- a/TeknoParrotUi.Common/ParrotData.cs
+++ b/TeknoParrotUi.Common/ParrotData.cs
@@ -27,5 +27,6 @@ namespace TeknoParrotUi.Common
         public string UiColour { get; set; } = "lightblue";
         public bool UiDarkMode { get; set; } = false;
         public bool UiHolidayThemes { get; set; } = true;
+        public bool UiPortableMode { get; set; } = false;
     }
 }

--- a/TeknoParrotUi/Properties/Resources-fi-FI.Designer.cs
+++ b/TeknoParrotUi/Properties/Resources-fi-FI.Designer.cs
@@ -833,6 +833,15 @@ namespace TeknoParrotUi.Properties {
                 return ResourceManager.GetString("SettingsUIHolidayThemes", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Kannettava tila.
+        /// </summary>
+        public static string SettingsUIPortableMode {
+            get {
+                return ResourceManager.GetString("SettingsUIPortableMode", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Onnistuneesti tallennettu {0}!.

--- a/TeknoParrotUi/Properties/Resources-fi-FI.resx
+++ b/TeknoParrotUi/Properties/Resources-fi-FI.resx
@@ -385,6 +385,9 @@
   <data name="SettingsUIHolidayThemes" xml:space="preserve">
     <value>Ota automaattisesti käyttöön lomakausien ulkoasuteemat.</value>
   </data>
+  <data name="SettingsUIPortableMode" xml:space="preserve">
+    <value>Kannettava tila</value>
+  </data>
   <data name="SuccessfullySaved" xml:space="preserve">
     <value>Onnistuneesti tallennettu {0}!</value>
     <comment>{0} = thing</comment>

--- a/TeknoParrotUi/Properties/Resources.Designer.cs
+++ b/TeknoParrotUi/Properties/Resources.Designer.cs
@@ -845,6 +845,15 @@ namespace TeknoParrotUi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Portable Mode.
+        /// </summary>
+        public static string SettingsUIPortableMode {
+            get {
+                return ResourceManager.GetString("SettingsUIPortableMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Successfully saved {0}!.
         /// </summary>
         public static string SuccessfullySaved {

--- a/TeknoParrotUi/Properties/Resources.resx
+++ b/TeknoParrotUi/Properties/Resources.resx
@@ -395,6 +395,9 @@ The following files may need to be removed from the game directory, unless you k
   <data name="SettingsUIHolidayThemes" xml:space="preserve">
     <value>Use a different theme on holidays</value>
   </data>
+  <data name="SettingsUIPortableMode" xml:space="preserve">
+    <value>Portable Mode</value>
+  </data>
   <data name="SuccessfullySaved" xml:space="preserve">
     <value>Successfully saved {0}!</value>
     <comment>{0} = thing</comment>

--- a/TeknoParrotUi/UserControls/SettingsControl.xaml
+++ b/TeknoParrotUi/UserControls/SettingsControl.xaml
@@ -34,6 +34,7 @@
                     <CheckBox Name="ChkUiDisableHardwareAcceleration" HorizontalAlignment="Center" Content="{x:Static p:Resources.SettingsHardwareAccel}"/>
                     <CheckBox Name="ChkUiDarkMode" HorizontalAlignment="Center" Content="{x:Static p:Resources.SettingsUIDarkMode}" Checked="ChkTheme_Checked" Unchecked="ChkTheme_Checked"/>
                     <CheckBox Name="ChkUiHolidayThemes" HorizontalAlignment="Center" Content="{x:Static p:Resources.SettingsUIHolidayThemes}" Checked="ChkTheme_Checked" Unchecked="ChkTheme_Checked"/>
+                    <CheckBox Name="ChkUiPortableMode" HorizontalAlignment="Center" Content="{x:Static p:Resources.SettingsUIPortableMode}"/>
                     <Separator/>
                     <StackPanel Name="UiPatreon">
                         <Label Content="{x:Static p:Resources.SettingsUICustomization}" HorizontalAlignment="Center" FontSize="30"/>

--- a/TeknoParrotUi/UserControls/SettingsControl.xaml.cs
+++ b/TeknoParrotUi/UserControls/SettingsControl.xaml.cs
@@ -47,6 +47,7 @@ namespace TeknoParrotUi.UserControls
             UiColour.SelectedItem = Lazydata.ParrotData.UiColour;
             ChkUiDarkMode.IsChecked = Lazydata.ParrotData.UiDarkMode;
             ChkUiHolidayThemes.IsChecked = Lazydata.ParrotData.UiHolidayThemes;
+            ChkUiPortableMode.IsChecked = Lazydata.ParrotData.UiPortableMode;
 
             if (App.IsPatreon())
             {
@@ -122,6 +123,7 @@ namespace TeknoParrotUi.UserControls
                 Lazydata.ParrotData.UiColour = UiColour.SelectedItem.ToString();
                 Lazydata.ParrotData.UiDarkMode = ChkUiDarkMode.IsChecked.Value;
                 Lazydata.ParrotData.UiHolidayThemes = ChkUiHolidayThemes.IsChecked.Value;
+                Lazydata.ParrotData.UiPortableMode = ChkUiPortableMode.IsChecked.Value;
 
                 DiscordRPC.StartOrShutdown();
 


### PR DESCRIPTION
I'm hoping someone can make use of this in the TP core to store EEPROM data in program directory (in a new sub dir) rather than %appdata%.