### PR TITLE
Fix crash when opening controller settings

### DIFF
--- a/TeknoParrotUi/Helpers/JoystickControlRawInput.cs
+++ b/TeknoParrotUi/Helpers/JoystickControlRawInput.cs
@@ -124,7 +124,16 @@ namespace TeknoParrotUi.Helpers
                 if(productName == "")
                     productName = "(Unknown product)";
 
-                fancyName = String.Format("{0} {1}", manufacturer, productName);
+                if(manufacturer == "(Standard keyboards)" || productName.Contains(manufacturer))
+                {
+                    // omit the manufacturer name
+                    fancyName = productName;
+                }
+                else
+                {
+                    // combined manufacturer / product name
+                    fancyName = String.Format("{0} {1}", manufacturer, productName);
+                }
             }
 
             return fancyName;

--- a/TeknoParrotUi/Helpers/JoystickControlRawInput.cs
+++ b/TeknoParrotUi/Helpers/JoystickControlRawInput.cs
@@ -116,12 +116,15 @@ namespace TeknoParrotUi.Helpers
             // Other
             if (fancyName == "")
             {
-                string manufacturer = device.ManufacturerName.Trim();
+                string manufacturer = device.ManufacturerName?.Trim() ?? "";
+                if(manufacturer == "")
+                    manufacturer = "(Unknown manufacturer)";
 
-                if (manufacturer == "(Standard keyboards)" || device.ProductName.Contains(manufacturer))
-                    manufacturer = "";
+                string productName = device.ProductName?.Trim() ?? "";
+                if(productName == "")
+                    productName = "(Unknown product)";
 
-                fancyName = String.Format("{0} {1}", manufacturer, device.ProductName.Trim()).Trim();
+                fancyName = String.Format("{0} {1}", manufacturer, productName);
             }
 
             return fancyName;


### PR DESCRIPTION
This PR will fix a potential crash when opening the controller setup dialog 
Fixes #270 

**Steps to reproduce:**

- Configure game input as "RawInput"
- Attach an USB device which doesn't provide proper ManufacturerName and / or ProductName values
- Open Controller setup

Application will crash due to a null reference error.