### PR TITLE
Fix pixelated game icons

### DIFF
--- a/TeknoParrotUi/Views/AddGame.xaml
+++ b/TeknoParrotUi/Views/AddGame.xaml
@@ -22,7 +22,7 @@
             <ColumnDefinition Width="271*"/>
             <ColumnDefinition Width="25*"/>
         </Grid.ColumnDefinitions>
-        <Image x:Name="gameIcon" HorizontalAlignment="Left" Height="244" Margin="13,150,0,0" VerticalAlignment="Top" Width="256" Grid.Column="2" Grid.Row="1" Grid.RowSpan="2"/>
+        <Image x:Name="gameIcon" HorizontalAlignment="Left" Height="244" Margin="13,150,0,0" VerticalAlignment="Top" Width="256" Grid.Column="2" Grid.Row="1" Grid.RowSpan="2" RenderOptions.BitmapScalingMode="Fant"/>
         <Viewbox Margin="10" Grid.Column="1" Grid.Row="2">
             <ListBox x:Name="stockGameList" HorizontalAlignment="Left" Height="638" Margin="20,16,0,0" VerticalAlignment="Top" Width="453" BorderThickness="1" SelectionChanged="StockGameList_SelectionChanged" Grid.Column="1" Grid.Row="2"/>
         </Viewbox>

--- a/TeknoParrotUi/Views/Library.xaml
+++ b/TeknoParrotUi/Views/Library.xaml
@@ -28,7 +28,7 @@
             <ColumnDefinition Width="21*"/>
             <ColumnDefinition Width="11*"/>
         </Grid.ColumnDefinitions>
-        <Image x:Name="gameIcon" Margin="10,10,10,12" Grid.Column="1" Grid.Row="2"/>
+        <Image x:Name="gameIcon" Margin="10,10,10,12" Grid.Column="1" Grid.Row="2" RenderOptions.BitmapScalingMode="Fant"/>
         <ListBox x:Name="gameList" HorizontalAlignment="Left" Margin="10,10,0,10" Width="493" BorderThickness="1" SelectionChanged="ListBox_SelectionChanged" Grid.Row="2" Grid.RowSpan="9"/>
         <Viewbox Stretch="UniformToFill"  Margin="10,4,358,4" Grid.RowSpan="2">
             <Label Content="{x:Static p:Resources.GameList}" Margin="10,7,392,2" RenderTransformOrigin="0.704,1.118" FontFamily="Roboto" FontSize="18" Grid.Row="1"/>


### PR DESCRIPTION
Game icons looked kinda ugly because of basically nearest neighbor filtering, especially in the library. This just sets it to filter the icons.