### PR TITLE
Fix WMMT game descriptions, add 5DX

### DIFF
--- a/TeknoParrotUi.Common/Descriptions/WMMT5.json
+++ b/TeknoParrotUi.Common/Descriptions/WMMT5.json
@@ -1,5 +1,5 @@
 {
-  "platform": "Namco ES3X",
+  "platform": "Namco ES3B",
   "release_year": "2014",
   "nvidia": "OK",
   "nvidia_issues": null,

--- a/TeknoParrotUi.Common/Descriptions/WMMT5DX.json
+++ b/TeknoParrotUi.Common/Descriptions/WMMT5DX.json
@@ -1,6 +1,6 @@
 {
   "platform": "Namco ES3B",
-  "release_year": "2018",
+  "release_year": "2015",
   "nvidia": "OK",
   "nvidia_issues": null,
   "amd": "OK",


### PR DESCRIPTION
Fixes the platform for WMMT5 and WMMT6, and adds a new description for 5DX seeing as OpenParrot now has code for it.