### PR TITLE
IDAS: notify amd users if driver is too new (thanks amd)

### DIFF
--- a/TeknoParrotUi/TeknoParrotUi.csproj
+++ b/TeknoParrotUi/TeknoParrotUi.csproj
@@ -130,6 +130,7 @@
     <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="System.Management" />
     <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
     </Reference>


### PR DESCRIPTION
AMD redid their opengl driver and managed to break everything in the process. For the time being, probably a good idea to let people know if their driver is too new, so they don't wonder why the game keeps crashing immediately on boot. 

(nez plz fix i wanna play d8)