### PR TITLE
Puck off expert mode

### DIFF
--- a/TeknoParrotUi.Common/GameProfiles/PuckOff.xml
+++ b/TeknoParrotUi.Common/GameProfiles/PuckOff.xml
@@ -110,7 +110,7 @@
 			<InputMapping>P1Button2</InputMapping>
 		</JoystickButtons>
 		<JoystickButtons>
-			<ButtonName>Comm</ButtonName>
+			<ButtonName>Hold 3s for Expert Mode</ButtonName>
 			<InputMapping>P1Button3</InputMapping>
 		</JoystickButtons>
 		<JoystickButtons>

--- a/TeknoParrotUi.Common/GameProfiles/PuckOff.xml
+++ b/TeknoParrotUi.Common/GameProfiles/PuckOff.xml
@@ -110,7 +110,7 @@
 			<InputMapping>P1Button2</InputMapping>
 		</JoystickButtons>
 		<JoystickButtons>
-			<ButtonName>Hold 3s for Expert Mode</ButtonName>
+			<ButtonName>Hold for Expert Mode</ButtonName>
 			<InputMapping>P1Button3</InputMapping>
 		</JoystickButtons>
 		<JoystickButtons>


### PR DESCRIPTION
Change label for comm button to Hold for Expert as this is how it functions in the game with TP
![Screenshot 2024-09-14 120110](https://github.com/user-attachments/assets/b69effb6-fbb7-4bb5-9e04-8622c1c0d3f8)
