### PR TITLE
Lets Go Safari executable fix

### DIFF
--- a/TeknoParrotUi.Common/GameProfiles/LGS.xml
+++ b/TeknoParrotUi.Common/GameProfiles/LGS.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <GameProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<GamePath></GamePath>
-	<TestMenuParameter>-t</TestMenuParameter>
-	<TestMenuIsExecutable>false</TestMenuIsExecutable>
+	<TestMenuParameter>GameTestR_Ringwide.exe</TestMenuParameter>
+	<TestMenuIsExecutable>true</TestMenuIsExecutable>
 	<ExtraParameters></ExtraParameters>
 	<TestMenuExtraParameters></TestMenuExtraParameters>
 	<EmulationProfile>LGS</EmulationProfile>
-	<GameProfileRevision>13</GameProfileRevision>
+	<GameProfileRevision>14</GameProfileRevision>
 	<HasSeparateTestMode>true</HasSeparateTestMode>
 	<EmulatorType>TeknoParrot</EmulatorType>
-	<ExecutableName>GameTestR_RingWide.exe</ExecutableName>
+	<ExecutableName>GameSampR_RingWide.exe</ExecutableName>
 	<ConfigValues>
 		<FieldInformation>
 			<CategoryName>General</CategoryName>

--- a/TeknoParrotUi.Common/GameSetup/LGS.xml
+++ b/TeknoParrotUi.Common/GameSetup/LGS.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <GameSetup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <GameExecutableLocation>GameTestR_RingWide.exe</GameExecutableLocation>
+  <GameExecutableLocation>GameSampR_RingWide.exe</GameExecutableLocation>
   <DevOnly>false</DevOnly>
 </GameSetup>


### PR DESCRIPTION
Executable fix. 
GameSampR_Ringwide.exe is the executable of the game.
GameTestR_Ringwide.exe is the executable of the testmenu.
Changed ExecutableName to GameSampR_Ringwide.exe and added GameTestR_Ringwide.exe to TestMenuExecutable.
Changed TestMenuIsExecutable to true.
Changed GameProfileRevision to 14.