### PR TITLE
Minor fix for previous BG4 Tuned PR, fix coin inputs

### DIFF
--- a/TeknoParrotUi.Common/GameProfiles/BattleGear4Tuned.xml
+++ b/TeknoParrotUi.Common/GameProfiles/BattleGear4Tuned.xml
@@ -6,7 +6,7 @@
 	<ExtraParameters></ExtraParameters>
 	<TestMenuExtraParameters></TestMenuExtraParameters>
 	<EmulationProfile>TaitoTypeXBattleGear</EmulationProfile>
-	<GameProfileRevision>26</GameProfileRevision>
+	<GameProfileRevision>27</GameProfileRevision>
 	<HasSeparateTestMode>false</HasSeparateTestMode>
 	<ExecutableName>game.exe</ExecutableName>
 	<EmulatorType>OpenParrot</EmulatorType>
@@ -138,7 +138,7 @@
 		</JoystickButtons>
 		<JoystickButtons>
 			<ButtonName>Coin</ButtonName>
-			<InputMapping>Service2</InputMapping>
+			<InputMapping>Coin1</InputMapping>
 		</JoystickButtons>
 		<JoystickButtons>
 			<ButtonName>Start</ButtonName>

--- a/TeknoParrotUi.Common/Jvs/JvsPackageEmulator.cs
+++ b/TeknoParrotUi.Common/Jvs/JvsPackageEmulator.cs
@@ -848,7 +848,7 @@ namespace TeknoParrotUi.Common.Jvs
             if (multiPackage)
                 byteLst.Add(0x01);
 
-            else if (Hotd4)
+            if (Hotd4)
             {
                 // P1 shake
                 InputCode.AnalogBytes[8] = (byte)(128 - Math.Min(Math.Abs(InputCode.AnalogBytes[0] - PrevAnalog[0]) * 3, 128));


### PR DESCRIPTION
See above.

Firstly profile update to fix coin input so it works in game profile, bumped GameProfileRevision.

Also fix to an else if I forgot to change to normal if in analogs reply (unsure if this might break HOTD4 depending on how it requests analogs?

Please review and advise as needed regarding changes etc.