### PR TITLE
Fix launcher button input mapping in Sengoku Basara X

### DIFF
--- a/TeknoParrotUi.Common/GameProfiles/sbxc.xml
+++ b/TeknoParrotUi.Common/GameProfiles/sbxc.xml
@@ -6,7 +6,7 @@
 	<ExtraParameters></ExtraParameters>
 	<TestMenuExtraParameters></TestMenuExtraParameters>
 	<EmulationProfile>PlayInput</EmulationProfile>
-	<GameProfileRevision>1</GameProfileRevision>
+	<GameProfileRevision>2</GameProfileRevision>
 	<HasSeparateTestMode>false</HasSeparateTestMode>
 	<EmulatorType>Play</EmulatorType>
 	<ValidMd5>MD5\sbxc.md5</ValidMd5>
@@ -107,7 +107,7 @@
 		</JoystickButtons>
 		<JoystickButtons>
 			<ButtonName>Player 1 Launcher</ButtonName>
-			<InputMapping>P1Button4</InputMapping>
+			<InputMapping>P1Button3</InputMapping>
 		</JoystickButtons>
 		<JoystickButtons>
 			<ButtonName>Player 1 Basara Arts</ButtonName>
@@ -143,7 +143,7 @@
 		</JoystickButtons>
 		<JoystickButtons>
 			<ButtonName>Player 2 Launcher</ButtonName>
-			<InputMapping>P2Button4</InputMapping>
+			<InputMapping>P2Button3</InputMapping>
 		</JoystickButtons>
 		<JoystickButtons>
 			<ButtonName>Player 2 Basara Arts</ButtonName>


### PR DESCRIPTION
Fixes wrong input mapping for the launcher button in Sengoku Basara X.